### PR TITLE
BIP 32 Seed Derivation

### DIFF
--- a/bst/src/bitcoin/mnemonics/bip_32_derivation.rs
+++ b/bst/src/bitcoin/mnemonics/bip_32_derivation.rs
@@ -1,0 +1,97 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::{build_utf8_mnemonic_string, MnemonicTextNormalizationSettings};
+use crate::{
+    hashing::{Hasher, Sha512},
+    String16,
+};
+use alloc::vec::Vec;
+use macros::s16;
+
+// Used to 'zero' mnemonic word vectors.
+const BLANK_STRING: String16 = s16!("");
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Bip32DevivationSettings {
+    text_normalization: MnemonicTextNormalizationSettings,
+    word_space_characters: String16<'static>,
+    salt_prefix: &'static [u8],
+    pbkdf2_iterations: u32,
+}
+
+impl Bip32DevivationSettings {
+    pub const fn from(
+        text_normalization: MnemonicTextNormalizationSettings,
+        word_space_characters: String16<'static>,
+        salt_prefix: &'static [u8],
+        pbkdf2_iterations: u32,
+    ) -> Self {
+        Self {
+            word_space_characters,
+            text_normalization,
+            pbkdf2_iterations,
+            salt_prefix,
+        }
+    }
+
+    pub fn derive_hd_wallet_seed(
+        &self,
+        mut extension_phrase: Vec<u16>,
+        mut mnemonic: Vec<String16<'static>>,
+    ) -> [u8; Sha512::HASH_SIZE] {
+        // Prepare the output buffer.
+        let mut output = [0u8; Sha512::HASH_SIZE];
+        {
+            // Normalize the extension phrase.
+            self.text_normalization
+                .normalize_text(&mut extension_phrase);
+
+            // String16 for operating on the extension phrase.
+            let extension_string = String16::from(&extension_phrase);
+
+            // Build a UTF8 encoded mnemonic string.
+            let mut mnemonic_string =
+                build_utf8_mnemonic_string(self.word_space_characters, &mnemonic);
+
+            // Prepare a UTF8 buffer for the salt.
+            let mut salt =
+                Vec::with_capacity(self.salt_prefix.len() + extension_string.utf8_content_length());
+
+            // Salts are prefixed, eg: utf8'mnemonic', or utf8'electrum'.
+            salt.extend(self.salt_prefix);
+
+            // Write the extension phrase to the salt buffer.
+            extension_string.write_content_to_utf8_vec(&mut salt);
+            extension_phrase.fill(0);
+
+            // Prepare the HMAC.
+            let mut hasher = Sha512::new();
+            let mut hmac = hasher.build_hmac(&mnemonic_string);
+            mnemonic_string.fill(0);
+
+            // Perform the PBKDF and write to the output buffer.
+            hmac.pbkdf2(&salt, self.pbkdf2_iterations, &mut output);
+
+            // Pre-emptively fill all remaining sensitive material.
+            mnemonic.fill(BLANK_STRING);
+            hasher.reset();
+            salt.fill(0);
+        }
+
+        output
+    }
+}

--- a/bst/src/bitcoin/mnemonics/bip_39/mnemonic_length.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mnemonic_length.rs
@@ -1,0 +1,53 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::String16;
+use macros::s16;
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub enum MnemonicLength {
+    Twelve,
+    Fifteen,
+    Eighteen,
+    TwentyOne,
+    TwentyFour,
+}
+
+impl Into<usize> for MnemonicLength {
+    fn into(self) -> usize {
+        match self {
+            MnemonicLength::Twelve => 12,
+            MnemonicLength::Fifteen => 15,
+            MnemonicLength::Eighteen => 18,
+            MnemonicLength::TwentyOne => 21,
+            MnemonicLength::TwentyFour => 24,
+        }
+    }
+}
+
+impl Into<String16<'static>> for MnemonicLength {
+    fn into(self) -> String16<'static> {
+        match self {
+            MnemonicLength::Twelve => s16!("Twelve Word"),
+            MnemonicLength::Fifteen => s16!("Fifteen Word"),
+            MnemonicLength::Eighteen => s16!("Eighteen Word"),
+            MnemonicLength::TwentyOne => s16!("Twenty One Word"),
+            MnemonicLength::TwentyFour => s16!("Twenty Four Word"),
+        }
+    }
+}
+
+impl crate::bitcoin::mnemonics::MnemonicLength for MnemonicLength {}

--- a/bst/src/bitcoin/mnemonics/bip_39/mod.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mod.rs
@@ -29,6 +29,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use macros::s16;
 
 pub const EXTENSION_PREFIX: &[u8] = "mnemonic".as_bytes();
+pub const SEED_DERIVATION_PBKDF_ITERATIONS: u32 = 2048;
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Bip39MnemonicLength {

--- a/bst/src/bitcoin/mnemonics/bip_39/mod.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mod.rs
@@ -20,6 +20,7 @@ pub use word_list::{BITS_PER_WORD, LONGEST_WORD_LENGTH, WORD_LIST};
 
 use super::{
     try_get_bit_at_index, try_get_bit_start_offset, try_get_word_index, try_set_bit_at_index,
+    ExtensionPhraseNormalizationSettings,
 };
 use crate::{
     hashing::{Hasher, Sha256},
@@ -30,6 +31,8 @@ use macros::s16;
 
 pub const EXTENSION_PREFIX: &[u8] = "mnemonic".as_bytes();
 pub const SEED_DERIVATION_PBKDF_ITERATIONS: u32 = 2048;
+pub const NORMALIZATION_SETTINGS: ExtensionPhraseNormalizationSettings =
+    ExtensionPhraseNormalizationSettings::from(false, false, false);
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Bip39MnemonicLength {

--- a/bst/src/bitcoin/mnemonics/bip_39/mod.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mod.rs
@@ -28,6 +28,8 @@ use crate::{
 use alloc::{boxed::Box, vec, vec::Vec};
 use macros::s16;
 
+pub const EXTENSION_PREFIX: &[u8] = "mnemonic".as_bytes();
+
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Bip39MnemonicLength {
     Twelve,

--- a/bst/src/bitcoin/mnemonics/bip_39/mod.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mod.rs
@@ -29,8 +29,9 @@ use crate::{
 use alloc::{boxed::Box, vec, vec::Vec};
 use macros::s16;
 
-pub const EXTENSION_PREFIX: &[u8] = "mnemonic".as_bytes();
+pub const MNEMONIC_WORD_SPACING: String16 = s16!(" ");
 pub const SEED_DERIVATION_PBKDF_ITERATIONS: u32 = 2048;
+pub const EXTENSION_PREFIX: &[u8] = "mnemonic".as_bytes();
 pub const NORMALIZATION_SETTINGS: ExtensionPhraseNormalizationSettings =
     ExtensionPhraseNormalizationSettings::from(false, false, false);
 

--- a/bst/src/bitcoin/mnemonics/bip_39/mod.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mod.rs
@@ -88,7 +88,7 @@ pub fn get_available_mnemonic_lengths(byte_count: usize) -> &'static [Bip39Mnemo
 
 pub const MAX_WORD_COUNT: usize = 24;
 
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Bip39MnemonicParsingResult<'a> {
     InvalidLength,
     InvalidWordEncountered(Bip39MnemonicLength, String16<'a>, usize),

--- a/bst/src/bitcoin/mnemonics/bip_39/mod.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/mod.rs
@@ -52,14 +52,39 @@ impl Into<usize> for Bip39MnemonicLength {
 impl Into<String16<'static>> for Bip39MnemonicLength {
     fn into(self) -> String16<'static> {
         match self {
-            Bip39MnemonicLength::Twelve => s16!("Twelve Words"),
-            Bip39MnemonicLength::Fifteen => s16!("Fifteen Words"),
-            Bip39MnemonicLength::Eighteen => s16!("Eighteen Words"),
-            Bip39MnemonicLength::TwentyOne => s16!("Twenty One Words"),
-            Bip39MnemonicLength::TwentyFour => s16!("Twenty Four Words"),
+            Bip39MnemonicLength::Twelve => s16!("Twelve Word"),
+            Bip39MnemonicLength::Fifteen => s16!("Fifteen Word"),
+            Bip39MnemonicLength::Eighteen => s16!("Eighteen Word"),
+            Bip39MnemonicLength::TwentyOne => s16!("Twenty One Word"),
+            Bip39MnemonicLength::TwentyFour => s16!("Twenty Four Word"),
         }
     }
 }
+
+const AVAILABLE_MNEMONIC_LENGTHS: [Bip39MnemonicLength; 5] = [
+    Bip39MnemonicLength::Twelve,
+    Bip39MnemonicLength::Fifteen,
+    Bip39MnemonicLength::Eighteen,
+    Bip39MnemonicLength::TwentyOne,
+    Bip39MnemonicLength::TwentyFour,
+];
+
+pub fn get_available_mnemonic_lengths(byte_count: usize) -> &'static [Bip39MnemonicLength] {
+    let mut count = 0;
+    for i in 0..AVAILABLE_MNEMONIC_LENGTHS.len() {
+        if required_bits_of_entropy_for_mnemonic_length(AVAILABLE_MNEMONIC_LENGTHS[i]) / 8
+            <= byte_count
+        {
+            count += 1;
+        } else {
+            break;
+        }
+    }
+
+    &AVAILABLE_MNEMONIC_LENGTHS[..count]
+}
+
+pub const MAX_WORD_COUNT: usize = 24;
 
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Bip39MnemonicParsingResult<'a> {

--- a/bst/src/bitcoin/mnemonics/bip_39/parser.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/parser.rs
@@ -1,0 +1,70 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::{
+    try_parse_bip39_mnemonic, MnemonicLength, MnemonicParsingResult, BIP_32_DERIVATION_SETTINGS,
+    MNEMONIC_FORMAT,
+};
+use crate::{
+    bitcoin::mnemonics::{Bip32DevivationSettings, MnemonicFormat, MnemonicParseResult},
+    String16,
+};
+use alloc::{boxed::Box, vec::Vec};
+
+pub struct MnemonicParser;
+
+impl crate::bitcoin::mnemonics::MnemonicParser for MnemonicParser {
+    type TParseResult = MnemonicParsingResult<'static>;
+    type TMnemonicLength = MnemonicLength;
+
+    fn try_decode_bytes(&self, words: &Vec<String16<'static>>) -> Self::TParseResult {
+        try_parse_bip39_mnemonic(&words)
+    }
+
+    fn mnemonic_format(&self) -> MnemonicFormat<Self::TMnemonicLength> {
+        MNEMONIC_FORMAT
+    }
+
+    fn bip_32_derivation_settings(&self) -> Bip32DevivationSettings {
+        BIP_32_DERIVATION_SETTINGS
+    }
+}
+
+fn mnemonic_is_acceptable<'a>(result: &MnemonicParsingResult<'a>) -> bool {
+    match result {
+        MnemonicParsingResult::InvalidChecksum(..) => true,
+        MnemonicParsingResult::Valid(_, _, _) => true,
+        _ => false,
+    }
+}
+
+impl<'a> MnemonicParseResult for MnemonicParsingResult<'a> {
+    fn can_derive_bip_32_seed(&self) -> bool {
+        mnemonic_is_acceptable(self)
+    }
+
+    fn get_bytes(self) -> Option<Box<[u8]>> {
+        match self {
+            MnemonicParsingResult::InvalidChecksum(_, bytes, _, _) => Some(bytes),
+            MnemonicParsingResult::Valid(_, bytes, _) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    fn can_get_bytes(&self) -> bool {
+        mnemonic_is_acceptable(self)
+    }
+}

--- a/bst/src/bitcoin/mnemonics/bip_39/parser.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/parser.rs
@@ -30,7 +30,7 @@ impl crate::bitcoin::mnemonics::MnemonicParser for MnemonicParser {
     type TParseResult = MnemonicParsingResult<'static>;
     type TMnemonicLength = MnemonicLength;
 
-    fn try_decode_bytes(&self, words: &Vec<String16<'static>>) -> Self::TParseResult {
+    fn try_parse_mnemonic(&self, words: &Vec<String16<'static>>) -> Self::TParseResult {
         try_parse_bip39_mnemonic(&words)
     }
 

--- a/bst/src/bitcoin/mnemonics/bip_39/word_list.rs
+++ b/bst/src/bitcoin/mnemonics/bip_39/word_list.rs
@@ -17,11 +17,9 @@
 use crate::String16;
 use macros::s16;
 
-pub const BITS_PER_WORD: u8 = 11;
-
-pub const LONGEST_WORD_LENGTH: u8 = 8;
-
-pub const WORD_LIST: [String16; 2048] = [
+pub const LONGEST_WORD_LENGTH: usize = 8;
+pub const BITS_PER_WORD: usize = 11;
+pub const WORDS: [String16; 2048] = [
     s16!("abandon"),
     s16!("ability"),
     s16!("able"),

--- a/bst/src/bitcoin/mnemonics/electrum/mnemonic_length.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mnemonic_length.rs
@@ -1,0 +1,53 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::String16;
+use macros::s16;
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub enum MnemonicLength {
+    Twelve,
+    Fifteen,
+    Eighteen,
+    TwentyOne,
+    TwentyFour,
+}
+
+impl Into<usize> for MnemonicLength {
+    fn into(self) -> usize {
+        match self {
+            MnemonicLength::Twelve => 12,
+            MnemonicLength::Fifteen => 15,
+            MnemonicLength::Eighteen => 18,
+            MnemonicLength::TwentyOne => 21,
+            MnemonicLength::TwentyFour => 24,
+        }
+    }
+}
+
+impl Into<String16<'static>> for MnemonicLength {
+    fn into(self) -> String16<'static> {
+        match self {
+            MnemonicLength::Twelve => s16!("Twelve Word"),
+            MnemonicLength::Fifteen => s16!("Fifteen Word"),
+            MnemonicLength::Eighteen => s16!("Eighteen Word"),
+            MnemonicLength::TwentyOne => s16!("Twenty One Word"),
+            MnemonicLength::TwentyFour => s16!("Twenty Four Word"),
+        }
+    }
+}
+
+impl crate::bitcoin::mnemonics::MnemonicLength for MnemonicLength {}

--- a/bst/src/bitcoin/mnemonics/electrum/mnemonic_version.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mnemonic_version.rs
@@ -21,32 +21,32 @@ pub const MNEMONIC_VERSION_HMAC_KEY: &[u8] = "Seed version".as_bytes();
 
 #[repr(u16)]
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-pub enum ElectrumMnemonicVersion {
+pub enum MnemonicVersion {
     Legacy = 0b0000000000000000,
     Segwit = 0b0000000000000001,
     Legacy2FA = 0b1000000000000000,
     Segwit2FA = 0b1000000000000001,
 }
 
-impl Into<String16<'static>> for ElectrumMnemonicVersion {
+impl Into<String16<'static>> for MnemonicVersion {
     fn into(self) -> String16<'static> {
         match self {
-            ElectrumMnemonicVersion::Legacy => s16!("Legacy"),
-            ElectrumMnemonicVersion::Segwit => s16!("Segwit"),
-            ElectrumMnemonicVersion::Legacy2FA => s16!("Legacy 2FA"),
-            ElectrumMnemonicVersion::Segwit2FA => s16!("Segwit 2FA"),
+            MnemonicVersion::Legacy => s16!("Legacy"),
+            MnemonicVersion::Segwit => s16!("Segwit"),
+            MnemonicVersion::Legacy2FA => s16!("Legacy 2FA"),
+            MnemonicVersion::Segwit2FA => s16!("Segwit 2FA"),
         }
     }
 }
 
 pub const fn mnemonic_prefix_validator(
-    mnemonic_version: ElectrumMnemonicVersion,
+    mnemonic_version: MnemonicVersion,
 ) -> fn(bytes: &[u8]) -> bool {
     match mnemonic_version {
-        ElectrumMnemonicVersion::Legacy => legacy_prefix_validator,
-        ElectrumMnemonicVersion::Segwit => segwit_prefix_validator,
-        ElectrumMnemonicVersion::Legacy2FA => legacy_2fa_prefix_validator,
-        ElectrumMnemonicVersion::Segwit2FA => segwit_2fa_prefix_validator,
+        MnemonicVersion::Legacy => legacy_prefix_validator,
+        MnemonicVersion::Segwit => segwit_prefix_validator,
+        MnemonicVersion::Legacy2FA => legacy_2fa_prefix_validator,
+        MnemonicVersion::Segwit2FA => segwit_2fa_prefix_validator,
     }
 }
 

--- a/bst/src/bitcoin/mnemonics/electrum/mod.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mod.rs
@@ -69,6 +69,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use macros::s16;
 
 pub const EXTENSION_PREFIX: &[u8] = "electrum".as_bytes();
+pub const SEED_DERIVATION_PBKDF_ITERATIONS: u32 = 2048;
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ElectrumMnemonicLength {

--- a/bst/src/bitcoin/mnemonics/electrum/mod.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mod.rs
@@ -68,6 +68,8 @@ use crate::{
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use macros::s16;
 
+pub const EXTENSION_PREFIX: &[u8] = "electrum".as_bytes();
+
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ElectrumMnemonicLength {
     Twelve,

--- a/bst/src/bitcoin/mnemonics/electrum/mod.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mod.rs
@@ -53,7 +53,7 @@ pub use mnemonic_version::ElectrumMnemonicVersion;
 
 use super::{
     bip_39::{try_read_mnemonic_bytes, BITS_PER_WORD},
-    format_mnemonic_string_utf8, try_get_bit_start_offset,
+    format_mnemonic_string_utf8, try_get_bit_start_offset, ExtensionPhraseNormalizationSettings,
 };
 use crate::{
     bitcoin::mnemonics::{
@@ -70,6 +70,9 @@ use macros::s16;
 
 pub const EXTENSION_PREFIX: &[u8] = "electrum".as_bytes();
 pub const SEED_DERIVATION_PBKDF_ITERATIONS: u32 = 2048;
+
+pub const NORMALIZATION_SETTINGS: ExtensionPhraseNormalizationSettings =
+    ExtensionPhraseNormalizationSettings::from(true, true, true);
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ElectrumMnemonicLength {

--- a/bst/src/bitcoin/mnemonics/electrum/mod.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mod.rs
@@ -259,7 +259,7 @@ fn required_bytes_of_entropy_for_mnemonic_length(mnemonic_length: MnemonicLength
 fn get_available_length_for_byte_count(byte_count: usize) -> &'static [MnemonicLength] {
     let mut count = 0;
     for i in 0..AVAILABLE_MNEMONIC_LENGTHS.len() {
-        if required_bits_of_entropy_for_mnemonic_length(AVAILABLE_MNEMONIC_LENGTHS[i]) / 8
+        if required_bytes_of_entropy_for_mnemonic_length(AVAILABLE_MNEMONIC_LENGTHS[i])
             <= byte_count
         {
             count += 1;

--- a/bst/src/bitcoin/mnemonics/electrum/mod.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mod.rs
@@ -68,9 +68,9 @@ use crate::{
 use alloc::{boxed::Box, vec, vec::Vec};
 use macros::s16;
 
-pub const EXTENSION_PREFIX: &[u8] = "electrum".as_bytes();
+pub const MNEMONIC_WORD_SPACING: String16 = s16!(" ");
 pub const SEED_DERIVATION_PBKDF_ITERATIONS: u32 = 2048;
-
+pub const EXTENSION_PREFIX: &[u8] = "electrum".as_bytes();
 pub const NORMALIZATION_SETTINGS: ExtensionPhraseNormalizationSettings =
     ExtensionPhraseNormalizationSettings::from(true, true, true);
 

--- a/bst/src/bitcoin/mnemonics/electrum/parser.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/parser.rs
@@ -1,0 +1,73 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::{
+    try_parse_electrum_mnemonic, MnemonicLength, MnemonicParsingResult, BIP_32_DERIVATION_SETTINGS,
+    MNEMONIC_FORMAT,
+};
+use crate::{
+    bitcoin::mnemonics::{Bip32DevivationSettings, MnemonicFormat, MnemonicParseResult},
+    String16,
+};
+use alloc::{boxed::Box, vec::Vec};
+
+pub struct MnemonicParser;
+
+impl crate::bitcoin::mnemonics::MnemonicParser for MnemonicParser {
+    type TParseResult = MnemonicParsingResult<'static>;
+    type TMnemonicLength = MnemonicLength;
+
+    fn try_decode_bytes(&self, words: &Vec<String16<'static>>) -> Self::TParseResult {
+        try_parse_electrum_mnemonic(&words)
+    }
+
+    fn mnemonic_format(&self) -> MnemonicFormat<Self::TMnemonicLength> {
+        MNEMONIC_FORMAT
+    }
+
+    fn bip_32_derivation_settings(&self) -> Bip32DevivationSettings {
+        BIP_32_DERIVATION_SETTINGS
+    }
+}
+
+impl<'a> MnemonicParseResult for MnemonicParsingResult<'a> {
+    fn can_derive_bip_32_seed(&self) -> bool {
+        match self {
+            MnemonicParsingResult::Valid(..) => true,
+            _ => false,
+        }
+    }
+
+    fn get_bytes(self) -> Option<Box<[u8]>> {
+        match self {
+            MnemonicParsingResult::InvalidVersion(_, bytes, _) => Some(bytes),
+            MnemonicParsingResult::OldFormat(_, bytes) => Some(bytes),
+            MnemonicParsingResult::Bip39(_, bytes, _) => Some(bytes),
+            MnemonicParsingResult::Valid(_, bytes, _) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    fn can_get_bytes(&self) -> bool {
+        match self {
+            MnemonicParsingResult::InvalidVersion(..) => true,
+            MnemonicParsingResult::OldFormat(..) => true,
+            MnemonicParsingResult::Bip39(..) => true,
+            MnemonicParsingResult::Valid(..) => true,
+            _ => false,
+        }
+    }
+}

--- a/bst/src/bitcoin/mnemonics/electrum/parser.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/parser.rs
@@ -30,7 +30,7 @@ impl crate::bitcoin::mnemonics::MnemonicParser for MnemonicParser {
     type TParseResult = MnemonicParsingResult<'static>;
     type TMnemonicLength = MnemonicLength;
 
-    fn try_decode_bytes(&self, words: &Vec<String16<'static>>) -> Self::TParseResult {
+    fn try_parse_mnemonic(&self, words: &Vec<String16<'static>>) -> Self::TParseResult {
         try_parse_electrum_mnemonic(&words)
     }
 

--- a/bst/src/bitcoin/mnemonics/mnemonic_formats.rs
+++ b/bst/src/bitcoin/mnemonics/mnemonic_formats.rs
@@ -1,0 +1,67 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::MnemonicWordList;
+use crate::String16;
+
+pub trait MnemonicLength: Copy + Into<usize> + Into<String16<'static>> + 'static {}
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MnemonicFormat<TMnemonicLength: MnemonicLength> {
+    get_available_lengths_for_byte_count: fn(usize) -> &'static [TMnemonicLength],
+    minimum_bytes_of_entropy: String16<'static>,
+    word_list: MnemonicWordList,
+    name: String16<'static>,
+    max_words: usize,
+}
+
+impl<TMnemonicLength: MnemonicLength> MnemonicFormat<TMnemonicLength> {
+    pub const fn from(
+        get_available_lengths_for_byte_count: fn(usize) -> &'static [TMnemonicLength],
+        minimum_bytes_of_entropy: String16<'static>,
+        word_list: MnemonicWordList,
+        name: String16<'static>,
+        max_words: usize,
+    ) -> Self {
+        Self {
+            get_available_lengths_for_byte_count,
+            minimum_bytes_of_entropy,
+            word_list,
+            max_words,
+            name,
+        }
+    }
+
+    pub const fn minimum_bytes_of_entropy(&self) -> String16 {
+        self.minimum_bytes_of_entropy
+    }
+
+    pub const fn word_list(&self) -> MnemonicWordList {
+        self.word_list
+    }
+
+    pub const fn max_words(&self) -> usize {
+        self.max_words
+    }
+
+    pub const fn name(&self) -> String16 {
+        self.name
+    }
+
+    pub fn get_available_lengths_for_byte_count(&self, byte_count: usize) -> &[TMnemonicLength] {
+        (self.get_available_lengths_for_byte_count)(byte_count)
+    }
+}

--- a/bst/src/bitcoin/mnemonics/mnemonic_text_normalization.rs
+++ b/bst/src/bitcoin/mnemonics/mnemonic_text_normalization.rs
@@ -1,0 +1,116 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::characters::Character;
+use alloc::vec::Vec;
+use macros::{c16, u16_array};
+
+// Non-decomposing characters to avoid needing NKDF normalization implementation.
+const ALLOWED_MNEMONIC_TEXT_CHARACTER: [u16; 102] =
+    u16_array!("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ \"'()+=-_[]{};:#@~,.<>/\\|%^&*¬`!¡?¿₿€£$¥");
+
+pub fn allow_mnemonic_text_character(character: u16) -> bool {
+    ALLOWED_MNEMONIC_TEXT_CHARACTER
+        .iter()
+        .position(|c| *c == character)
+        .is_some()
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MnemonicTextNormalizationSettings {
+    lowercase_characters: bool,
+    collapse_whitespace: bool,
+    trim_whitespace: bool,
+}
+
+impl MnemonicTextNormalizationSettings {
+    pub const fn from(
+        lowercase_characters: bool,
+        collapse_whitespace: bool,
+        trim_whitespace: bool,
+    ) -> Self {
+        Self {
+            lowercase_characters,
+            collapse_whitespace,
+            trim_whitespace,
+        }
+    }
+
+    pub fn normalize_text(&self, text: &mut Vec<u16>) {
+        if self.trim_whitespace {
+            // If we want to trim whitespace, start at the beginning, and remove any whitespace.
+            while text.len() > 0 {
+                if text[0].is_whitespace() {
+                    text.remove(0);
+                } else {
+                    // If we encounter any non-whitespace character, we can stop.
+                    break;
+                }
+            }
+
+            if text.len() == 0 {
+                // If we've emptied the vector by trimming whitespace (it was entirely filled with whitespace), we can return.
+                return;
+            }
+
+            // Now we can check the end.
+            while text[text.len() - 1].is_whitespace() {
+                text.pop();
+            }
+        }
+
+        let mut index = 0;
+        while index < text.len() {
+            let character = text[index];
+            if !allow_mnemonic_text_character(character) {
+                // If the character isn't allowed, get rid of it;
+                // we shouldn't hit this in reality as we should sanitize at input time.
+                text.remove(index);
+
+                // We want to check this index again, because we just removed the character at this index, so continue.
+                continue;
+            }
+
+            if self.collapse_whitespace && character.is_whitespace() {
+                // We've encountered a whitespace character, and we want to collapse whitespace.
+                while index < text.len() - 1 && text[index + 1].is_whitespace() {
+                    // Collapse any whitespace immediately following this character until there's none left.
+                    text.remove(index + 1);
+                }
+            }
+
+            if self.lowercase_characters {
+                // We want all characters to be lowercase; replace this character with its lowercase variant.
+                text[index] = self.lowercase(character);
+            }
+
+            index += 1;
+        }
+    }
+
+    fn lowercase(&self, character: u16) -> u16 {
+        if !self.lowercase_characters {
+            return character;
+        }
+
+        if character >= c16!("A") && character <= c16!("Z") {
+            // UTF 8 'A' is 0x41, and 'a' is 0x61. A-Z and a-z are uninterrupted, and in order.
+            character + 0x20
+        } else {
+            character
+        }
+    }
+}

--- a/bst/src/bitcoin/mnemonics/mnemonic_text_normalization.rs
+++ b/bst/src/bitcoin/mnemonics/mnemonic_text_normalization.rs
@@ -93,24 +93,16 @@ impl MnemonicTextNormalizationSettings {
             }
 
             if self.lowercase_characters {
-                // We want all characters to be lowercase; replace this character with its lowercase variant.
-                text[index] = self.lowercase(character);
+                // Swap the character at the current index with its lowercase variant.
+                text[index] = if character >= c16!("A") && character <= c16!("Z") {
+                    // UTF 8 'A' is 0x41, and 'a' is 0x61. A-Z and a-z are uninterrupted, and in order.
+                    character + 0x20
+                } else {
+                    character
+                }
             }
 
             index += 1;
-        }
-    }
-
-    fn lowercase(&self, character: u16) -> u16 {
-        if !self.lowercase_characters {
-            return character;
-        }
-
-        if character >= c16!("A") && character <= c16!("Z") {
-            // UTF 8 'A' is 0x41, and 'a' is 0x61. A-Z and a-z are uninterrupted, and in order.
-            character + 0x20
-        } else {
-            character
         }
     }
 }

--- a/bst/src/bitcoin/mnemonics/mod.rs
+++ b/bst/src/bitcoin/mnemonics/mod.rs
@@ -36,6 +36,7 @@ pub fn allow_extension_phrase_character(character: u16) -> bool {
         .is_some()
 }
 
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ExtensionPhraseNormalizationSettings {
     lowercase_characters: bool,
     collapse_whitespace: bool,

--- a/bst/src/bitcoin/mnemonics/mod.rs
+++ b/bst/src/bitcoin/mnemonics/mod.rs
@@ -51,34 +51,6 @@ pub trait MnemonicParseResult {
     fn can_get_bytes(&self) -> bool;
 }
 
-pub fn build_utf8_mnemonic_string<'a>(
-    word_space_characters: String16<'a>,
-    mnemonic: &Vec<String16<'a>>,
-) -> Vec<u8> {
-    // No words, no output.
-    if mnemonic.len() == 0 {
-        return Vec::with_capacity(0);
-    }
-
-    // Count the total number of characters required.
-    let words_character_count: usize = mnemonic.iter().map(|w| w.utf8_content_length()).sum();
-    let space_character_count = (mnemonic.len() - 1) * word_space_characters.utf8_content_length();
-
-    // Prepare a buffer, then fill it one word at a time.
-    let mut mnemonic_string = Vec::with_capacity(space_character_count + words_character_count);
-    for i in 0..(mnemonic.len() - 1) {
-        // Copy the word into the buffer.
-        mnemonic[i].write_content_to_utf8_vec(&mut mnemonic_string);
-
-        // Space after every word but the last.
-        word_space_characters.write_content_to_utf8_vec(&mut mnemonic_string);
-    }
-
-    // Last word, no space.
-    mnemonic[mnemonic.len() - 1].write_content_to_utf8_vec(&mut mnemonic_string);
-    mnemonic_string
-}
-
 const fn try_get_bit_start_offset(bit_count: usize, byte_count: usize) -> Option<usize> {
     let available_bits = byte_count * 8;
     if available_bits < bit_count {
@@ -117,4 +89,32 @@ const fn try_get_bit_at_index(bit_index: usize, bytes: &[u8]) -> Option<bool> {
     let bit_index = bit_index % 8;
     let bit_mask = 0b10000000u8 >> bit_index;
     Some((bit_mask & byte) != 0)
+}
+
+fn build_utf8_mnemonic_string<'a>(
+    word_space_characters: String16<'a>,
+    mnemonic: &Vec<String16<'a>>,
+) -> Vec<u8> {
+    // No words, no output.
+    if mnemonic.len() == 0 {
+        return Vec::with_capacity(0);
+    }
+
+    // Count the total number of characters required.
+    let words_character_count: usize = mnemonic.iter().map(|w| w.utf8_content_length()).sum();
+    let space_character_count = (mnemonic.len() - 1) * word_space_characters.utf8_content_length();
+
+    // Prepare a buffer, then fill it one word at a time.
+    let mut mnemonic_string = Vec::with_capacity(space_character_count + words_character_count);
+    for i in 0..(mnemonic.len() - 1) {
+        // Copy the word into the buffer.
+        mnemonic[i].write_content_to_utf8_vec(&mut mnemonic_string);
+
+        // Space after every word but the last.
+        word_space_characters.write_content_to_utf8_vec(&mut mnemonic_string);
+    }
+
+    // Last word, no space.
+    mnemonic[mnemonic.len() - 1].write_content_to_utf8_vec(&mut mnemonic_string);
+    mnemonic_string
 }

--- a/bst/src/bitcoin/mnemonics/mod.rs
+++ b/bst/src/bitcoin/mnemonics/mod.rs
@@ -36,7 +36,7 @@ pub trait MnemonicParser {
     type TParseResult: MnemonicParseResult;
     type TMnemonicLength: MnemonicLength;
 
-    fn try_decode_bytes(&self, words: &Vec<String16<'static>>) -> Self::TParseResult;
+    fn try_parse_mnemonic(&self, words: &Vec<String16<'static>>) -> Self::TParseResult;
 
     fn mnemonic_format(&self) -> MnemonicFormat<Self::TMnemonicLength>;
 

--- a/bst/src/bitcoin/mnemonics/mod.rs
+++ b/bst/src/bitcoin/mnemonics/mod.rs
@@ -55,9 +55,9 @@ pub fn format_mnemonic_string_utf8<'a>(
 
 pub fn derive_hd_wallet_seed(
     mut mnemonic: Vec<String16<'static>>,
-    mut passphrase: Vec<u16>,
     word_space: String16<'static>,
     extension_prefix: &[u8],
+    passphrase: &mut [u16],
     iterations: u32,
 ) -> [u8; Sha512::HASH_SIZE] {
     // Prepare the output buffer.
@@ -74,7 +74,7 @@ pub fn derive_hd_wallet_seed(
         // Salts are prefixed, eg: utf8'mnemonic', or utf8'electrum'.
         salt.extend(extension_prefix);
 
-        // Write the extension phrase to the salt buffer. TODO: Unicode Normalization.
+        // Write the extension phrase to the salt buffer. TODO: NORMALIZATION.
         p.extend_utf8_vec_with_content(&mut salt);
 
         // Prepare the HMAC.

--- a/bst/src/bitcoin/mnemonics/mod.rs
+++ b/bst/src/bitcoin/mnemonics/mod.rs
@@ -26,36 +26,9 @@ use macros::s16;
 
 pub const BLANK_STRING: String16 = s16!("");
 
-pub fn format_mnemonic_string_utf16(
-    mnemonic: &Vec<String16<'static>>,
-    space: String16<'static>,
-) -> Vec<u16> {
-    // No words, no output.
-    if mnemonic.len() == 0 {
-        return Vec::with_capacity(0);
-    }
-
-    // Count the total number of characters required.
-    let word_characters: usize = mnemonic.iter().map(|w| w.content_length()).sum();
-    let space_characters = (mnemonic.len() - 1) * space.content_length();
-
-    // Prepare a vec, then fill it one word at a time.
-    let mut vec = Vec::with_capacity(space_characters + word_characters);
-    for i in 0..(mnemonic.len() - 1) {
-        mnemonic[i].extend_utf16_vec_with_content(&mut vec);
-
-        // Space after every word but the last.
-        space.extend_utf16_vec_with_content(&mut vec);
-    }
-
-    // Last word, no space.
-    mnemonic[mnemonic.len() - 1].extend_utf16_vec_with_content(&mut vec);
-    vec
-}
-
-pub fn format_mnemonic_string_utf8(
-    mnemonic: &Vec<String16<'static>>,
-    space: String16<'static>,
+pub fn format_mnemonic_string_utf8<'a>(
+    mnemonic: &Vec<String16<'a>>,
+    space: String16<'a>,
 ) -> Vec<u8> {
     // No words, no output.
     if mnemonic.len() == 0 {

--- a/bst/src/bitcoin/mnemonics/mod.rs
+++ b/bst/src/bitcoin/mnemonics/mod.rs
@@ -17,139 +17,43 @@
 pub mod bip_39;
 pub mod electrum;
 
-use crate::{
-    characters::Character,
-    hashing::{Hasher, Sha512},
-    String16,
+mod bip_32_derivation;
+mod mnemonic_formats;
+mod mnemonic_text_normalization;
+mod word_lists;
+
+pub use bip_32_derivation::Bip32DevivationSettings;
+pub use mnemonic_formats::{MnemonicFormat, MnemonicLength};
+pub use mnemonic_text_normalization::{
+    allow_mnemonic_text_character, MnemonicTextNormalizationSettings,
 };
-use alloc::vec::Vec;
-use macros::{c16, s16, u16_array};
+pub use word_lists::MnemonicWordList;
 
-// Non-decomposing characters to avoid needing NKDF normalization implementation.
-const ALLOWED_EXTENSION_PHRASE_CHARACTERS: [u16; 102] =
-    u16_array!("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ \"'()+=-_[]{};:#@~,.<>/\\|%^&*¬`!¡?¿₿€£$¥");
+use crate::String16;
+use alloc::{boxed::Box, vec::Vec};
 
-pub fn allow_extension_phrase_character(character: u16) -> bool {
-    ALLOWED_EXTENSION_PHRASE_CHARACTERS
-        .iter()
-        .position(|c| *c == character)
-        .is_some()
+pub trait MnemonicParser {
+    type TParseResult: MnemonicParseResult;
+    type TMnemonicLength: MnemonicLength;
+
+    fn try_decode_bytes(&self, words: &Vec<String16<'static>>) -> Self::TParseResult;
+
+    fn mnemonic_format(&self) -> MnemonicFormat<Self::TMnemonicLength>;
+
+    fn bip_32_derivation_settings(&self) -> Bip32DevivationSettings;
 }
 
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-pub struct ExtensionPhraseNormalizationSettings {
-    lowercase_characters: bool,
-    collapse_whitespace: bool,
-    trim_whitespace: bool,
+pub trait MnemonicParseResult {
+    fn can_derive_bip_32_seed(&self) -> bool;
+
+    fn get_bytes(self) -> Option<Box<[u8]>>;
+
+    fn can_get_bytes(&self) -> bool;
 }
 
-impl ExtensionPhraseNormalizationSettings {
-    const fn from(
-        lowercase_characters: bool,
-        collapse_whitespace: bool,
-        trim_whitespace: bool,
-    ) -> Self {
-        Self {
-            lowercase_characters,
-            collapse_whitespace,
-            trim_whitespace,
-        }
-    }
-
-    fn process(&self, vec: &mut Vec<u16>) {
-        if self.trim_whitespace {
-            // If we want to trim whitespace, start at the beginning, and remove any whitespace.
-            while vec.len() > 0 {
-                if vec[0].is_whitespace() {
-                    vec.remove(0);
-                } else {
-                    // If we encounter any non-whitespace character, we can stop.
-                    break;
-                }
-            }
-
-            if vec.len() == 0 {
-                // If we've emptied the vector by trimming whitespace (it was entirely filled with whitespace), we can return.
-                return;
-            }
-
-            // Now we can check the end.
-            while vec[vec.len() - 1].is_whitespace() {
-                vec.pop();
-            }
-        }
-
-        let mut index = 0;
-        while index < vec.len() {
-            let character = vec[index];
-            if !allow_extension_phrase_character(character) {
-                // If the character isn't allowed, get rid of it;
-                // we shouldn't hit this in reality as we should sanitize at input time.
-                vec.remove(index);
-
-                // We want to check this index again, because we just removed the character at this index, so continue.
-                continue;
-            }
-
-            if self.collapse_whitespace && character.is_whitespace() {
-                // We've encountered a whitespace character, and we want to collapse whitespace.
-                while index < vec.len() - 1 && vec[index + 1].is_whitespace() {
-                    // Collapse any whitespace immediately following this character until there's none left.
-                    vec.remove(index + 1);
-                }
-            }
-
-            if self.lowercase_characters {
-                // We want all characters to be lowercase; replace this character with its lowercase variant.
-                vec[index] = self.lowercase(character);
-            }
-
-            index += 1;
-        }
-    }
-
-    fn lowercase(&self, character: u16) -> u16 {
-        if !self.lowercase_characters {
-            return character;
-        }
-
-        match character {
-            c16!("A") => c16!("a"),
-            c16!("B") => c16!("b"),
-            c16!("C") => c16!("c"),
-            c16!("D") => c16!("d"),
-            c16!("E") => c16!("e"),
-            c16!("F") => c16!("f"),
-            c16!("G") => c16!("g"),
-            c16!("H") => c16!("h"),
-            c16!("I") => c16!("i"),
-            c16!("J") => c16!("j"),
-            c16!("K") => c16!("k"),
-            c16!("L") => c16!("l"),
-            c16!("M") => c16!("m"),
-            c16!("N") => c16!("n"),
-            c16!("O") => c16!("o"),
-            c16!("P") => c16!("p"),
-            c16!("Q") => c16!("q"),
-            c16!("R") => c16!("r"),
-            c16!("S") => c16!("s"),
-            c16!("T") => c16!("t"),
-            c16!("U") => c16!("u"),
-            c16!("V") => c16!("v"),
-            c16!("W") => c16!("w"),
-            c16!("X") => c16!("x"),
-            c16!("Y") => c16!("y"),
-            c16!("Z") => c16!("z"),
-            _ => character,
-        }
-    }
-}
-
-pub const BLANK_STRING: String16 = s16!("");
-
-pub fn format_mnemonic_string_utf8<'a>(
+pub fn build_utf8_mnemonic_string<'a>(
+    word_space_characters: String16<'a>,
     mnemonic: &Vec<String16<'a>>,
-    space: String16<'a>,
 ) -> Vec<u8> {
     // No words, no output.
     if mnemonic.len() == 0 {
@@ -157,67 +61,22 @@ pub fn format_mnemonic_string_utf8<'a>(
     }
 
     // Count the total number of characters required.
-    let word_characters: usize = mnemonic.iter().map(|w| w.content_length_utf8()).sum();
-    let space_characters = (mnemonic.len() - 1) * space.content_length_utf8();
+    let words_character_count: usize = mnemonic.iter().map(|w| w.utf8_content_length()).sum();
+    let space_character_count = (mnemonic.len() - 1) * word_space_characters.utf8_content_length();
 
-    // Prepare a vec, then fill it one word at a time.
-    let mut vec = Vec::with_capacity(space_characters + word_characters);
+    // Prepare a buffer, then fill it one word at a time.
+    let mut mnemonic_string = Vec::with_capacity(space_character_count + words_character_count);
     for i in 0..(mnemonic.len() - 1) {
-        mnemonic[i].extend_utf8_vec_with_content(&mut vec);
+        // Copy the word into the buffer.
+        mnemonic[i].write_content_to_utf8_vec(&mut mnemonic_string);
 
         // Space after every word but the last.
-        space.extend_utf8_vec_with_content(&mut vec);
+        word_space_characters.write_content_to_utf8_vec(&mut mnemonic_string);
     }
 
     // Last word, no space.
-    mnemonic[mnemonic.len() - 1].extend_utf8_vec_with_content(&mut vec);
-    vec
-}
-
-pub fn derive_hd_wallet_seed(
-    normalization_settings: ExtensionPhraseNormalizationSettings,
-    mut mnemonic: Vec<String16<'static>>,
-    word_space: String16<'static>,
-    mut passphrase: Vec<u16>,
-    extension_prefix: &[u8],
-    iterations: u32,
-) -> [u8; Sha512::HASH_SIZE] {
-    // Prepare the output buffer.
-    let mut output = [0u8; Sha512::HASH_SIZE];
-    {
-        normalization_settings.process(&mut passphrase);
-        let p = String16::from(&passphrase);
-
-        // Get the UTF8 version of the mnemonic string.
-        let mut mnemonic_string = format_mnemonic_string_utf8(&mnemonic, word_space);
-
-        // Prepare a UTF8 buffer for the salt.
-        let mut salt = Vec::with_capacity(extension_prefix.len() + p.content_length_utf8());
-
-        // Salts are prefixed, eg: utf8'mnemonic', or utf8'electrum'.
-        salt.extend(extension_prefix);
-
-        // Write the extension phrase to the salt buffer.
-        p.extend_utf8_vec_with_content(&mut salt);
-
-        // Prepare the HMAC.
-        let mut hasher = Sha512::new();
-        let mut hmac = hasher.build_hmac(&mnemonic_string);
-
-        // We don't need the mnemonic string anymore, it was just the key, so pre-emptively fill it.
-        mnemonic_string.fill(0);
-
-        // Perform the PBKDF and write to the output buffer.
-        hmac.pbkdf2(&salt, iterations, &mut output);
-
-        // Pre-emptively fill all this sensitive material.
-        mnemonic.fill(BLANK_STRING);
-        passphrase.fill(0);
-        hasher.reset();
-        salt.fill(0);
-    }
-
-    output
+    mnemonic[mnemonic.len() - 1].write_content_to_utf8_vec(&mut mnemonic_string);
+    mnemonic_string
 }
 
 const fn try_get_bit_start_offset(bit_count: usize, byte_count: usize) -> Option<usize> {
@@ -258,32 +117,4 @@ const fn try_get_bit_at_index(bit_index: usize, bytes: &[u8]) -> Option<bool> {
     let bit_index = bit_index % 8;
     let bit_mask = 0b10000000u8 >> bit_index;
     Some((bit_mask & byte) != 0)
-}
-
-fn try_get_word_index(
-    start_bit_offset: usize,
-    word_number: usize,
-    bits_per_word: u8,
-    bytes: &[u8],
-) -> Option<usize> {
-    if bits_per_word > 64 {
-        // We unwrap into a usize so we can index a word list; we can't support more than 64 bits per word.
-        // It's OK though... there's not that many words.
-        return None;
-    }
-
-    let start = start_bit_offset + (word_number * (bits_per_word as usize));
-    let end = start + (bits_per_word as usize);
-    if end > bytes.len() * 8 {
-        return None;
-    }
-
-    let mut index = 0usize;
-    for i in start..end {
-        // Read the bits one at a time into the index; we're just building up a base 2 number.
-        index *= 2;
-        index += try_get_bit_at_index(i, bytes).unwrap() as usize;
-    }
-
-    Some(index)
 }

--- a/bst/src/bitcoin/mnemonics/word_lists.rs
+++ b/bst/src/bitcoin/mnemonics/word_lists.rs
@@ -1,0 +1,134 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::{try_get_bit_at_index, try_get_bit_start_offset};
+use crate::{bitcoin::mnemonics::try_set_bit_at_index, String16};
+use alloc::{vec, vec::Vec};
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MnemonicWordList {
+    words: &'static [String16<'static>],
+    longest_word_length: usize,
+    name: String16<'static>,
+    bits_per_word: usize,
+}
+
+impl MnemonicWordList {
+    pub const fn from(
+        words: &'static [String16<'static>],
+        longest_word_length: usize,
+        name: String16<'static>,
+        bits_per_word: usize,
+    ) -> Self {
+        Self {
+            longest_word_length,
+            bits_per_word,
+            words,
+            name,
+        }
+    }
+
+    pub const fn words(&self) -> &[String16<'static>] {
+        self.words
+    }
+
+    pub const fn longest_word_length(&self) -> usize {
+        self.longest_word_length
+    }
+
+    pub const fn bits_per_word(&self) -> usize {
+        self.bits_per_word
+    }
+
+    pub const fn name(&self) -> String16 {
+        self.name
+    }
+
+    pub fn try_get_word(
+        &self,
+        start_bit_offset: usize,
+        word_number: usize,
+        bytes: &[u8],
+    ) -> Option<String16<'static>> {
+        if self.bits_per_word > 64 {
+            // We unwrap into a usize so we can index a word list; we can't support more than 64 bits per word.
+            // It's OK though... there's not that many words.
+            return None;
+        }
+
+        let start = start_bit_offset + (word_number * (self.bits_per_word));
+        let end = start + (self.bits_per_word);
+        if end > bytes.len() * 8 {
+            return None;
+        }
+
+        let mut index = 0usize;
+        for i in start..end {
+            // Read the bits one at a time into the index; we're just building up a base 2 number.
+            index *= 2;
+            index += try_get_bit_at_index(i, bytes).unwrap() as usize;
+        }
+
+        Some(self.words[index])
+    }
+
+    pub fn try_read_mnemonic_bytes<'a>(
+        &self,
+        mnemonic_byte_count: usize,
+        mnemonic_bit_count: usize,
+        words: &Vec<String16<'a>>,
+    ) -> Result<(usize, Vec<u8>), (String16<'a>, usize)> {
+        // Initialize a byte vector for reading the mnemonic into.
+        let mut mnemonic_bytes = vec![0u8; mnemonic_byte_count];
+
+        // Calculate the offset to write the mnemonic's bits at.
+        let mnemonic_bit_start_offset =
+            try_get_bit_start_offset(mnemonic_bit_count, mnemonic_byte_count).unwrap();
+
+        // Iterate over the words in the mnemonic.
+        for i in 0..words.len() {
+            let word = words[i];
+
+            // Look for the word in the word list.
+            let word = match self
+                .words
+                .binary_search_by(|w| w.content_iterator().cmp(word.content_iterator()))
+            {
+                Ok(i) => i,
+                Err(_) => {
+                    // We couldn't find the word in the word list; return an error.
+                    return Err((word, i));
+                }
+            }
+            .to_be_bytes();
+
+            // Get the start offset for the word's bits.
+            let word_bit_start_offset =
+                try_get_bit_start_offset(self.bits_per_word, word.len()).unwrap();
+
+            // Write the word's bits to the mnemonic byte buffer.
+            for j in 0..self.bits_per_word {
+                assert!(try_set_bit_at_index(
+                    mnemonic_bit_start_offset + (i * self.bits_per_word) + j,
+                    try_get_bit_at_index(word_bit_start_offset + j, &word).unwrap(),
+                    &mut mnemonic_bytes,
+                ));
+            }
+        }
+
+        Ok((mnemonic_bit_start_offset, mnemonic_bytes))
+    }
+}

--- a/bst/src/clipboard.rs
+++ b/bst/src/clipboard.rs
@@ -19,7 +19,7 @@ use alloc::sync::Arc;
 use core::mem;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ClipboardEntry {
     Empty,
     Bytes(String16<'static>, Arc<[u8]>),

--- a/bst/src/clipboard.rs
+++ b/bst/src/clipboard.rs
@@ -18,7 +18,6 @@ use crate::String16;
 use alloc::sync::Arc;
 use core::mem;
 
-#[allow(dead_code)]
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ClipboardEntry {
     Empty,
@@ -30,7 +29,6 @@ pub struct Clipboard {
     entries: [ClipboardEntry; 10],
 }
 
-#[allow(dead_code)]
 impl Clipboard {
     pub const fn new() -> Self {
         Self {
@@ -47,10 +45,6 @@ impl Clipboard {
                 ClipboardEntry::Empty,
             ],
         }
-    }
-
-    pub const fn entry_count(&self) -> usize {
-        self.entries.len()
     }
 
     pub const fn get_entries(&self) -> &[ClipboardEntry] {

--- a/bst/src/hashing/sha_512.rs
+++ b/bst/src/hashing/sha_512.rs
@@ -28,10 +28,11 @@ pub struct Sha512 {
 }
 
 impl Sha512 {
+    pub const HASH_SIZE: usize = 64;
+
     const PADDING_BUFFER_LENGTH: usize = Self::BLOCK_SIZE + 16;
     const ALGORITHM_NAME: String16<'static> = s16!("SHA512");
     const BLOCK_SIZE: usize = 128;
-    const HASH_SIZE: usize = 64;
 
     const SEED: [u64; 8] = [
         0x6A09E667F3BCC908,

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -73,29 +73,11 @@ impl Ord for BigInteger {
     }
 }
 
-#[allow(dead_code)]
 impl BigInteger {
     pub fn from_be_bytes(bytes: &[u8]) -> Self {
         Self {
             bytes: Vec::from(bytes),
         }
-    }
-
-    pub fn copy_bytes_from(&mut self, bytes: &[u8]) {
-        // Match the internal buffer's length to the length of the provided bytes.
-        if self.bytes.len() < bytes.len() {
-            // Expand the internal byte buffer to the input bytes' length.
-            self.bytes.reserve(bytes.len() - self.bytes.len());
-            while self.bytes.len() < bytes.len() {
-                self.bytes.push(0);
-            }
-        } else {
-            // Truncate the internal byte buffer to the input bytes' length.
-            self.bytes.truncate(bytes.len());
-        }
-
-        // Copy the provided bytes to the internal buffer.
-        self.bytes.copy_from_slice(bytes);
     }
 
     pub fn take_ownership_of_bytes(self) -> Vec<u8> {

--- a/bst/src/integers/numeric_base.rs
+++ b/bst/src/integers/numeric_base.rs
@@ -251,11 +251,6 @@ impl NumericBase {
         self.small_title
     }
 
-    #[allow(dead_code)]
-    pub const fn name(&self) -> String16<'static> {
-        self.name
-    }
-
     pub const fn base(&self) -> u8 {
         self.base
     }

--- a/bst/src/integers/numeric_base.rs
+++ b/bst/src/integers/numeric_base.rs
@@ -106,7 +106,7 @@ impl ConsoleWriteable for NumericBases {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct NumericBaseWithCharacterPredicate {
     whitespace_allowed_character_predicate: fn(character: u16) -> bool,
     base: &'static NumericBase,
@@ -132,7 +132,7 @@ impl NumericBaseWithCharacterPredicate {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct NumericBase {
     // We can 'ignore' case.
     alternate_characters: Option<&'static [u16]>,

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -70,7 +70,6 @@ pub struct NumericCollector {
     bit_counter: f64,
 }
 
-#[allow(dead_code)]
 impl NumericCollector {
     pub fn with_byte_capacity(capacity: usize) -> Self {
         Self {
@@ -164,21 +163,11 @@ impl NumericCollector {
         r
     }
 
-    pub fn copy_trimmed_bytes_to(&self, buffer: &mut [u8]) {
-        self.big_integer.copy_bytes_to(buffer);
-    }
-
     pub fn copy_padded_bytes_to(&self, buffer: &mut [u8]) {
         let padding = self.padded_byte_count() - self.trimmed_byte_count();
         self.big_integer.copy_bytes_to(&mut buffer[padding..]);
         // Make sure our leading zeroes are actually zeroes.
         buffer[..padding].fill(0);
-    }
-
-    pub fn set_content_to(&mut self, bytes: &[u8]) {
-        // We assume all the bits had a chance at being a 1.
-        self.bit_counter += bytes.len() as f64 * 8f64;
-        self.big_integer.copy_bytes_from(bytes);
     }
 
     pub fn trimmed_byte_count(&self) -> usize {

--- a/bst/src/programs/console/entropy/mnemonics/bip_39.rs
+++ b/bst/src/programs/console/entropy/mnemonics/bip_39.rs
@@ -16,7 +16,7 @@
 
 use super::{
     bip_39_word_list_mnemonic_decoder::{
-        Bip39BasedMnemonicParseResult, ConsoleBip39WordListMnemonicDecoder,
+        Bip39BasedMnemonicParseResult, ConsoleBip39WordListMnemonicEntropyDecoder,
     },
     bip_39_word_list_mnemonic_encoder::ConsoleBip39WordListMnemonicEncoder,
 };
@@ -58,14 +58,14 @@ pub fn get_bip_39_mnemonic_program_list<
                     "An unknown error occurred while generating the mnemonic."
                 ))),
             },
-            s16!("BIP 39 Mnemonic Encoder"),
+            s16!("BIP 39 Mnemonic Entropy Encoder"),
             system_services.clone(),
             s16!("16"),
             s16!("BIP 39"),
             required_bits_of_entropy_for_mnemonic_length,
         )),
-        Arc::from(ConsoleBip39WordListMnemonicDecoder::from(
-            s16!("BIP 39 Mnemonic Decoder"),
+        Arc::from(ConsoleBip39WordListMnemonicEntropyDecoder::from(
+            s16!("BIP 39 Mnemonic Entropy Decoder"),
             mnemonic_parser,
             system_services.clone(),
             s16!("BIP 39"),
@@ -116,6 +116,14 @@ impl<'a> Bip39BasedMnemonicParseResult for Bip39MnemonicParsingResult<'a> {
             Bip39MnemonicParsingResult::InvalidChecksum(_, bytes, _, _) => Some(bytes),
             Bip39MnemonicParsingResult::Valid(_, bytes, _) => Some(bytes),
             _ => None,
+        }
+    }
+
+    fn can_get_bytes(&self) -> bool {
+        match self {
+            Bip39MnemonicParsingResult::InvalidChecksum(..) => true,
+            Bip39MnemonicParsingResult::Valid(..) => true,
+            _ => false,
         }
     }
 }

--- a/bst/src/programs/console/entropy/mnemonics/bip_39.rs
+++ b/bst/src/programs/console/entropy/mnemonics/bip_39.rs
@@ -15,15 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-    mnemonic_bip_32_seed_deriver::{ConsoleMnemonicBip39SeedDeriver, MnemonicSeedDeriveResult},
-    mnemonic_entropy_decoder::{ConsoleMnemonicEntropyDecoder, MnemonicByteParseResult},
-    mnemonic_entropy_encoder::ConsoleMnemonicEntropyEncoder,
+    mnemonic_bip_32_seed_deriver::ConsoleMnemonicBip39SeedDeriver,
+    mnemonic_entropy_decoder::ConsoleMnemonicEntropyDecoder,
+    mnemonic_entropy_encoder::{ConsoleMnemonicEntropyEncoder, MnemonicEncoder},
 };
 use crate::{
-    bitcoin::mnemonics::bip_39::{
-        self, required_bits_of_entropy_for_mnemonic_length, try_generate_bip_39_mnemonic,
-        try_parse_bip39_mnemonic, Bip39MnemonicLength, Bip39MnemonicParsingResult,
-    },
+    bitcoin::mnemonics::{bip_39, MnemonicFormat},
     console_out::ConsoleOut,
     constants,
     programs::{
@@ -35,7 +32,7 @@ use crate::{
     ui::console::ConsoleWriteable,
     String16,
 };
-use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use macros::s16;
 
 pub fn get_bip_39_mnemonic_program_list<
@@ -50,39 +47,20 @@ pub fn get_bip_39_mnemonic_program_list<
 ) -> ProgramListProgram<TProgramSelector, TProgramExitResultHandler> {
     let programs: [Arc<dyn Program>; 3] = [
         Arc::from(ConsoleMnemonicEntropyEncoder::from(
-            bip_39::get_available_mnemonic_lengths,
-            s16!("BIP 39"),
-            &bip_39::WORD_LIST,
-            s16!("16"),
-            s16!("BIP 39"),
             system_services.clone(),
-            mnemonic_encoder,
+            Encoder,
             s16!("BIP 39 Entropy Encoder"),
         )),
         Arc::from(ConsoleMnemonicEntropyDecoder::from(
             s16!("BIP 39 Mnemonic Bytes"),
-            s16!("BIP 39"),
-            &bip_39::WORD_LIST,
-            s16!("BIP 39"),
+            bip_39::MnemonicParser,
             system_services.clone(),
-            mnemonic_parser,
-            bip_39::LONGEST_WORD_LENGTH as usize,
             s16!("BIP 39 Entropy Decoder"),
-            bip_39::MAX_WORD_COUNT,
         )),
         Arc::from(ConsoleMnemonicBip39SeedDeriver::from(
-            bip_39::NORMALIZATION_SETTINGS,
-            bip_39::MNEMONIC_WORD_SPACING,
-            s16!("BIP 39"),
-            &bip_39::WORD_LIST,
-            s16!("BIP 39"),
             system_services.clone(),
-            mnemonic_parser,
-            bip_39::EXTENSION_PREFIX,
-            bip_39::LONGEST_WORD_LENGTH as usize,
+            bip_39::MnemonicParser,
             s16!("BIP 39 Mnemonic To BIP 32 Seed"),
-            bip_39::SEED_DERIVATION_PBKDF_ITERATIONS,
-            bip_39::MAX_WORD_COUNT,
         )),
     ];
 
@@ -90,43 +68,63 @@ pub fn get_bip_39_mnemonic_program_list<
         .as_program(program_selector.clone(), exit_result_handler.clone())
 }
 
-fn mnemonic_encoder<TSystemServices: SystemServices>(
-    _system_services: &TSystemServices,
-    mnemonic_length: Bip39MnemonicLength,
-    bytes: &[u8],
-) -> Result<Vec<String16<'static>>, Option<String16<'static>>> {
-    match try_generate_bip_39_mnemonic(mnemonic_length, bytes) {
-        Some(m) => Ok(m),
-        // We should ever expect this to get hit.
-        None => Err(Some(s16!(
-            "An unknown error occurred while generating the mnemonic."
-        ))),
+struct Encoder;
+
+impl MnemonicEncoder for Encoder {
+    type TMnemonicLength = bip_39::MnemonicLength;
+
+    fn mnemnonic_format(&self) -> MnemonicFormat<Self::TMnemonicLength> {
+        bip_39::MNEMONIC_FORMAT
+    }
+
+    fn try_encode<TSystemServices: SystemServices>(
+        &self,
+        bytes: &[u8],
+        _system_services: &TSystemServices,
+        mnemonic_length: Self::TMnemonicLength,
+    ) -> Result<Vec<String16<'static>>, Option<String16<'static>>> {
+        match bip_39::try_generate_mnemonic(mnemonic_length, bytes) {
+            Some(m) => Ok(m),
+            // We should never expect this to get hit.
+            None => Err(Some(s16!(
+                "An unknown error occurred while generating the mnemonic."
+            ))),
+        }
     }
 }
 
-fn mnemonic_parser(words: &Vec<String16<'static>>) -> Bip39MnemonicParsingResult<'static> {
-    try_parse_bip39_mnemonic(&words)
+impl ConsoleWriteable for bip_39::MnemonicLength {
+    fn write_to<T: ConsoleOut>(&self, console: &T) {
+        super::write_mnemonic_length_to(
+            (*self).into(),
+            bip_39::required_bits_of_entropy_for_mnemonic_length(*self),
+            console,
+        );
+    }
 }
 
-impl<'a> ConsoleWriteable for Bip39MnemonicParsingResult<'a> {
+impl<'a> ConsoleWriteable for bip_39::MnemonicParsingResult<'a> {
     fn write_to<T: ConsoleOut>(&self, console: &T) {
         match self {
-            Bip39MnemonicParsingResult::InvalidLength => console
+            bip_39::MnemonicParsingResult::InvalidLength => console
                 .in_colours(constants::ERROR_COLOURS, |c| {
                     c.output_utf16(s16!("Invalid Length"))
                 }),
-            Bip39MnemonicParsingResult::InvalidWordEncountered(_, w, _) => console
+            bip_39::MnemonicParsingResult::InvalidWordEncountered(_, w, _) => console
                 .in_colours(constants::ERROR_COLOURS, |c| {
                     c.output_utf16(s16!("Invalid word: ")).output_utf16(*w)
                 }),
-            Bip39MnemonicParsingResult::InvalidChecksum(length, _, checksum, expected_checksum) => {
-                console.in_colours(constants::WARNING_COLOURS, |c| {
-                    c.output_utf16((*length).into())
-                        .output_utf16(s16!(" Mnemonic failed checksum; expected "))
-                        .output_utf32(&format!("{}, got {}.\0", expected_checksum, checksum))
-                })
-            }
-            Bip39MnemonicParsingResult::Valid(length, _, checksum) => {
+            bip_39::MnemonicParsingResult::InvalidChecksum(
+                length,
+                _,
+                checksum,
+                expected_checksum,
+            ) => console.in_colours(constants::WARNING_COLOURS, |c| {
+                c.output_utf16((*length).into())
+                    .output_utf16(s16!(" Mnemonic failed checksum; expected "))
+                    .output_utf32(&format!("{}, got {}.\0", expected_checksum, checksum))
+            }),
+            bip_39::MnemonicParsingResult::Valid(length, _, checksum) => {
                 console.in_colours(constants::SUCCESS_COLOURS, |c| {
                     c.output_utf16((*length).into())
                         .output_utf16(s16!(" Mnemonic passed checksum of "))
@@ -134,46 +132,5 @@ impl<'a> ConsoleWriteable for Bip39MnemonicParsingResult<'a> {
                 })
             }
         };
-    }
-}
-
-impl<'a> MnemonicByteParseResult for Bip39MnemonicParsingResult<'a> {
-    fn get_bytes(self) -> Option<Box<[u8]>> {
-        match self {
-            Bip39MnemonicParsingResult::InvalidChecksum(_, bytes, _, _) => Some(bytes),
-            Bip39MnemonicParsingResult::Valid(_, bytes, _) => Some(bytes),
-            _ => None,
-        }
-    }
-
-    fn can_get_bytes(&self) -> bool {
-        match self {
-            Bip39MnemonicParsingResult::InvalidChecksum(..) => true,
-            Bip39MnemonicParsingResult::Valid(..) => true,
-            _ => false,
-        }
-    }
-}
-
-impl<'a> MnemonicSeedDeriveResult for Bip39MnemonicParsingResult<'a> {
-    fn can_derive_seed(&self) -> bool {
-        match self {
-            Bip39MnemonicParsingResult::InvalidChecksum(..) => true,
-            Bip39MnemonicParsingResult::Valid(..) => true,
-            _ => false,
-        }
-    }
-}
-
-impl ConsoleWriteable for Bip39MnemonicLength {
-    fn write_to<T: ConsoleOut>(&self, console: &T) {
-        console
-            .output_utf16((*self).into())
-            .output_utf16(s16!(" ("))
-            .output_utf32(&format!(
-                "{}\0",
-                required_bits_of_entropy_for_mnemonic_length(*self)
-            ))
-            .output_utf16(s16!(" bits)"));
     }
 }

--- a/bst/src/programs/console/entropy/mnemonics/bip_39_word_list_mnemonic_decoder.rs
+++ b/bst/src/programs/console/entropy/mnemonics/bip_39_word_list_mnemonic_decoder.rs
@@ -19,23 +19,23 @@ use crate::{
     clipboard::ClipboardEntry,
     console_out::ConsoleOut,
     constants,
-    keyboard_in::{BehaviourKey, Key, KeyboardIn},
     programs::{console::write_bytes, Program, ProgramExitResult},
     system_services::SystemServices,
-    ui::{
-        console::{prompt_for_clipboard_write, ConsoleUiLabel, ConsoleUiTitle, ConsoleWriteable},
-        Point,
+    ui::console::{
+        get_mnemonic_input, prompt_for_clipboard_write, ConsoleUiTitle, ConsoleWriteable,
     },
     String16,
 };
 use alloc::{boxed::Box, vec::Vec};
-use macros::{c16, s16};
+use macros::s16;
 
 pub trait Bip39BasedMnemonicParseResult: ConsoleWriteable {
     fn get_bytes(self) -> Option<Box<[u8]>>;
+
+    fn can_get_bytes(&self) -> bool;
 }
 
-pub struct ConsoleBip39WordListMnemonicDecoder<
+pub struct ConsoleBip39WordListMnemonicEntropyDecoder<
     TSystemServices: SystemServices,
     TMnemonicParseResult: Bip39BasedMnemonicParseResult,
     FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
@@ -51,7 +51,12 @@ impl<
         TSystemServices: SystemServices,
         TMnemonicParseResult: Bip39BasedMnemonicParseResult,
         FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
-    > ConsoleBip39WordListMnemonicDecoder<TSystemServices, TMnemonicParseResult, FMnemonicParser>
+    >
+    ConsoleBip39WordListMnemonicEntropyDecoder<
+        TSystemServices,
+        TMnemonicParseResult,
+        FMnemonicParser,
+    >
 {
     pub const fn from(
         name: String16<'static>,
@@ -75,17 +80,17 @@ impl<
         TMnemonicParseResult: Bip39BasedMnemonicParseResult,
         FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
     > Program
-    for ConsoleBip39WordListMnemonicDecoder<TSystemServices, TMnemonicParseResult, FMnemonicParser>
+    for ConsoleBip39WordListMnemonicEntropyDecoder<
+        TSystemServices,
+        TMnemonicParseResult,
+        FMnemonicParser,
+    >
 {
     fn name(&self) -> String16<'static> {
         self.name
     }
 
     fn run(&self) -> ProgramExitResult {
-        // Readers beware... This program has a fairly complicated UI. I'd recommend checking out some of the other programs first
-        // if you haven't already, to get familiar with how BST UIs are written so the weirder stuff here isn't as hard to 'get'.
-        // Definitely at least try USING this UI before trying to read the code.
-
         let console = self.system_services.get_console_out();
         console.clear();
 
@@ -97,305 +102,29 @@ impl<
                 " Mnemonic Format utilizing the BIP 39 word list, validates it, and extracts the underlying bytes."
             )).in_colours(constants::WARNING_COLOURS, |c|c.output_utf16_line(s16!("NOTE: This is not the same as building a HD wallet seed!")));
 
-        let console_width = console.size().width();
-        const MAX_WORDS: usize = 24;
+        let mnemonic_input_result = get_mnemonic_input::<_, TMnemonicParseResult, _, _>(
+            |r| r.can_get_bytes(),
+            &self.system_services,
+            &self.mnemonic_parser,
+            &WORD_LIST,
+            5,
+            LONGEST_WORD_LENGTH as usize,
+            24,
+        );
 
-        // A buffer for input truncation.
-        let mut input_buffer = [0u16; MAX_WORDS * (LONGEST_WORD_LENGTH as usize + 1)];
+        match mnemonic_input_result {
+            Some((_, parse_result)) => match parse_result.get_bytes() {
+                Some(bytes) => {
+                    write_bytes(&self.system_services, self.clipboard_entry_name, &bytes);
+                    prompt_for_clipboard_write(
+                        &self.system_services,
+                        ClipboardEntry::Bytes(self.clipboard_entry_name, bytes.into()),
+                    );
 
-        // A buffer for the individual mnemonic words.
-        let mut words: Vec<String16> = Vec::with_capacity(MAX_WORDS);
-
-        // A buffer for inputting mnemonic words one at a time.
-        let mut current_word_buffer = [0u16; LONGEST_WORD_LENGTH as usize];
-        let mut current_word_buffer_count = 0;
-
-        // 'Possible word list' dimensions.
-        let words_per_row = console_width / (LONGEST_WORD_LENGTH as usize + 1);
-        const POSSIBLE_WORD_ROWS: usize = 5;
-
-        // Write the input UI structure; entered mnemonic label first.
-        ConsoleUiLabel::from(s16!("Entered Mnemonic")).write_to(&console);
-
-        // Make space for the mnemonic line.
-        console.line_start().new_line();
-
-        // Write the mnemonic info label.
-        ConsoleUiLabel::from(s16!("Mnemonic Information")).write_to(&console);
-
-        // Make space for the status line.
-        console.line_start().new_line();
-
-        // Write the possible words list label.
-        ConsoleUiLabel::from(s16!("Possible Words")).write_to(&console);
-
-        // Make sure we have space to write five rows of possible words.
-        console.line_start();
-        for _ in 0..POSSIBLE_WORD_ROWS {
-            console.new_line();
-        }
-
-        // Write the exit message.
-        console.in_colours(constants::PROMPT_COLOURS, |c| {
-            c.output_utf16(s16!("Press ESC to complete input."))
-        });
-
-        // Calculate positions for UI elements.
-        let end_position = console.cursor().position();
-        let word_list_position = Point::from(0, end_position.y() - POSSIBLE_WORD_ROWS);
-        let mnemonic_info_position = word_list_position - Point::from(0, 3);
-        let mnemonic_input_position = mnemonic_info_position - Point::from(0, 3);
-
-        // Get the keyboard input provider.
-        let keyboard_in = self.system_services.get_keyboard_in();
-
-        // A place to store mnemonic bytes.
-        let mut mnemonic_bytes: Option<Box<[u8]>>;
-        loop {
-            // A flag indicating whether the user should be allowed to input more words.
-            let allow_more_words = words.len() < 24;
-
-            // If there's at least one possible word for input, the first gets stored here.
-            let mut completion_word = None;
-
-            // Move the cursor position to the possible word list space.
-            console.set_cursor_position(word_list_position);
-            if allow_more_words {
-                // Get the current word's input so far.
-                let word_buffer_content = &current_word_buffer[..current_word_buffer_count];
-
-                // Work out the possible words given the current word input.
-                let possible_words = WORD_LIST
-                    .iter()
-                    .filter(|w| {
-                        w.content_length() >= current_word_buffer_count
-                            && &w.content_slice()[..current_word_buffer_count]
-                                == word_buffer_content
-                    })
-                    .take(POSSIBLE_WORD_ROWS * words_per_row);
-
-                // Track the number of words we've written in the current line.
-                let mut line_word_counter = 0;
-
-                // Write the possible word list.
-                for word in possible_words {
-                    let blanking = 9 - word.content_length();
-                    match completion_word {
-                        Some(_) => {
-                            console
-                                .output_utf16(word.clone())
-                                .blank_up_to_line_end(blanking);
-                        }
-                        None => {
-                            // Highlight the first word, as that's the one that would be autocompleted on space key press.
-                            console.in_colours(constants::PROMPT_COLOURS, |c| {
-                                c.output_utf16(word.clone()).blank_up_to_line_end(blanking)
-                            });
-
-                            completion_word = Some(word);
-                        }
-                    }
-
-                    line_word_counter += 1;
-                    if words_per_row == line_word_counter {
-                        // Handle any remainder of the screen width.
-                        console.blank_remaining_line();
-                        line_word_counter = 0;
-                    }
+                    ProgramExitResult::Success
                 }
-            }
-
-            // Blank any remaining lines in the word list space.
-            while console.cursor().position().y() < end_position.y() {
-                console.blank_remaining_line();
-            }
-
-            // Parse the mnemonic input.
-            let parse_result = (self.mnemonic_parser)(&words);
-
-            // Write information about the current mnemonic input.
-            console.set_cursor_position(mnemonic_info_position);
-            parse_result.write_to(&console);
-            console.blank_remaining_line();
-
-            // Get the byte option from the parse result.
-            mnemonic_bytes = parse_result.get_bytes();
-
-            // Write the current input to the input line buffer.
-            let mut input_buffer_offset = 0;
-            for word in &words {
-                // Get the length of the word.
-                let word_length = word.content_length();
-
-                // Write the word to the buffer.
-                input_buffer[input_buffer_offset..input_buffer_offset + word_length]
-                    .copy_from_slice(word.content_slice());
-
-                // Write a space to the buffer.
-                input_buffer[input_buffer_offset + word_length] = c16!(" ");
-
-                // Add the word and space's length to the offset.
-                input_buffer_offset += word_length + 1;
-            }
-
-            if allow_more_words {
-                // If there's space for more words, write the current word buffer to the input buffer.
-                input_buffer[input_buffer_offset..input_buffer_offset + current_word_buffer_count]
-                    .copy_from_slice(&current_word_buffer[..current_word_buffer_count]);
-
-                // Update the offset; we want a null at the end, so add an extra 1.
-                input_buffer_offset += current_word_buffer_count + 1;
-            }
-
-            // Fill the remaining buffer with null.
-            input_buffer[input_buffer_offset - 1..].fill(0);
-
-            // Move the cursor to the mnemonic input line.
-            console.set_cursor_position(mnemonic_input_position);
-            console.in_colours(
-                if completion_word.is_none() && current_word_buffer_count > 0 {
-                    // There's no possible words, and we've started writing one; the input is bad.
-                    constants::ERROR_COLOURS
-                } else {
-                    constants::DEFAULT_COLOURS
-                },
-                |c| {
-                    if input_buffer_offset > console_width {
-                        // If there's not enough space to write the entire mnemonic, start with an ellipsis.
-                        c.output_utf16(s16!("..."))
-                            // Then write the tail of the input buffer.
-                            .output_utf16(String16::from(
-                                // +4 for ellipsis and a cursor space.
-                                &input_buffer
-                                    [input_buffer_offset - console_width + 4..input_buffer_offset],
-                            ))
-                    } else {
-                        // If there's enough space to write the entire mnemonic, just write it.
-                        c.output_utf16(String16::from(&input_buffer[..input_buffer_offset]))
-                    }
-                },
-            );
-
-            // Get the position where the input ends.
-            let input_cursor_position = console.cursor().position();
-
-            // Blank then go back to the end of the line.
-            console
-                .blank_remaining_line()
-                .set_cursor_position(input_cursor_position);
-
-            // Show the cursor during input.
-            console.set_cursor_visibility(true);
-
-            // A flag indicating whether an exit has been requested.
-            let mut exit = false;
-
-            // Only re-draw when there's some actual change.
-            loop {
-                // Read some input.
-                let key = keyboard_in.read_key();
-
-                // Hide the cursor the rest of the time.
-                console.set_cursor_visibility(false);
-
-                match key.key() {
-                    Key::Behaviour(b) => match b {
-                        BehaviourKey::Escape => {
-                            console.set_cursor_position(end_position).line_start();
-                            exit = true;
-                            break;
-                        }
-                        BehaviourKey::BackSpace => {
-                            if current_word_buffer_count > 0 {
-                                // If we've started writing a word, pop the last character.
-                                current_word_buffer[current_word_buffer_count - 1] = 0;
-                                current_word_buffer_count -= 1;
-                                break;
-                            }
-
-                            if words.len() > 0 {
-                                // If we've not started writing a new word, but there are previous words,
-                                // move the previous word into the current word buffer.
-                                let word = words.pop().unwrap();
-                                current_word_buffer_count = word.content_length();
-                                current_word_buffer[..current_word_buffer_count]
-                                    .copy_from_slice(word.content_slice());
-                                break;
-                            }
-                        }
-                        _ => {}
-                    },
-                    Key::Digit(_) => { /* Ignore digits. */ }
-                    Key::Symbol(s) => match s {
-                        c16!("a")
-                        | c16!("b")
-                        | c16!("c")
-                        | c16!("d")
-                        | c16!("e")
-                        | c16!("f")
-                        | c16!("g")
-                        | c16!("h")
-                        | c16!("i")
-                        | c16!("j")
-                        | c16!("k")
-                        | c16!("l")
-                        | c16!("m")
-                        | c16!("n")
-                        | c16!("o")
-                        | c16!("p")
-                        | c16!("q")
-                        | c16!("r")
-                        | c16!("s")
-                        | c16!("t")
-                        | c16!("u")
-                        | c16!("v")
-                        | c16!("w")
-                        | c16!("x")
-                        | c16!("y")
-                        | c16!("z") => {
-                            if allow_more_words
-                                && current_word_buffer_count < current_word_buffer.len()
-                            {
-                                // If there's space, write the character to the current word buffer.
-                                current_word_buffer[current_word_buffer_count] = s;
-                                current_word_buffer_count += 1;
-                                break;
-                            }
-                        }
-                        c16!(" ") => match completion_word {
-                            Some(w) => {
-                                if allow_more_words {
-                                    // Add the word to the word list.
-                                    words.push(*w);
-
-                                    // Then clear the current word buffer.
-                                    current_word_buffer_count = 0;
-                                    current_word_buffer.fill(0);
-                                    break;
-                                }
-                            }
-                            None => { /* There's no possible word, so don't do anything. */ }
-                        },
-                        _ => { /* Ignore any other symbol input. */ }
-                    },
-                }
-            }
-
-            if exit {
-                break;
-            }
-        }
-
-        match mnemonic_bytes {
-            Some(bytes) => {
-                write_bytes(&self.system_services, self.clipboard_entry_name, &bytes);
-                prompt_for_clipboard_write(
-                    &self.system_services,
-                    ClipboardEntry::Bytes(self.clipboard_entry_name, bytes.into()),
-                );
-
-                ProgramExitResult::Success
-            }
+                None => ProgramExitResult::UserCancelled,
+            },
             None => ProgramExitResult::UserCancelled,
         }
     }

--- a/bst/src/programs/console/entropy/mnemonics/electrum.rs
+++ b/bst/src/programs/console/entropy/mnemonics/electrum.rs
@@ -16,7 +16,7 @@
 
 use super::{
     bip_39_word_list_mnemonic_decoder::{
-        Bip39BasedMnemonicParseResult, ConsoleBip39WordListMnemonicDecoder,
+        Bip39BasedMnemonicParseResult, ConsoleBip39WordListMnemonicEntropyDecoder,
     },
     bip_39_word_list_mnemonic_encoder::ConsoleBip39WordListMnemonicEncoder,
 };
@@ -107,14 +107,14 @@ pub fn get_electrum_mnemonic_program_list<
                     Err(e) => Err(Some(e)),
                 }
             },
-            s16!("Electrum Mnemonic Encoder (BIP 39 Word List)"),
+            s16!("Electrum Mnemonic Entropy Encoder (BIP 39 Word List)"),
             system_services.clone(),
             s16!("17"),
             s16!("Electrum"),
             required_bits_of_entropy_for_mnemonic_length,
         )),
-        Arc::from(ConsoleBip39WordListMnemonicDecoder::from(
-            s16!("Electrum Mnemonic Decoder (BIP 39 Word List)"),
+        Arc::from(ConsoleBip39WordListMnemonicEntropyDecoder::from(
+            s16!("Electrum Mnemonic Entropy Decoder (BIP 39 Word List)"),
             mnemonic_parser,
             system_services.clone(),
             s16!("Electrum"),
@@ -182,11 +182,21 @@ impl<'a> ConsoleWriteable for ElectrumMnemonicParsingResult<'a> {
 impl<'a> Bip39BasedMnemonicParseResult for ElectrumMnemonicParsingResult<'a> {
     fn get_bytes(self) -> Option<Box<[u8]>> {
         match self {
-            ElectrumMnemonicParsingResult::OldFormat(_, bytes) => Some(bytes),
             ElectrumMnemonicParsingResult::InvalidVersion(_, bytes, _) => Some(bytes),
+            ElectrumMnemonicParsingResult::OldFormat(_, bytes) => Some(bytes),
             ElectrumMnemonicParsingResult::Bip39(_, bytes, _) => Some(bytes),
             ElectrumMnemonicParsingResult::Valid(_, bytes, _) => Some(bytes),
             _ => None,
+        }
+    }
+
+    fn can_get_bytes(&self) -> bool {
+        match self {
+            ElectrumMnemonicParsingResult::InvalidVersion(..) => true,
+            ElectrumMnemonicParsingResult::OldFormat(..) => true,
+            ElectrumMnemonicParsingResult::Bip39(..) => true,
+            ElectrumMnemonicParsingResult::Valid(..) => true,
+            _ => false,
         }
     }
 }

--- a/bst/src/programs/console/entropy/mnemonics/electrum.rs
+++ b/bst/src/programs/console/entropy/mnemonics/electrum.rs
@@ -15,19 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-    mnemonic_bip_32_seed_deriver::{ConsoleMnemonicBip39SeedDeriver, MnemonicSeedDeriveResult},
-    mnemonic_entropy_decoder::{ConsoleMnemonicEntropyDecoder, MnemonicByteParseResult},
-    mnemonic_entropy_encoder::ConsoleMnemonicEntropyEncoder,
+    mnemonic_bip_32_seed_deriver::ConsoleMnemonicBip39SeedDeriver,
+    mnemonic_entropy_decoder::ConsoleMnemonicEntropyDecoder,
+    mnemonic_entropy_encoder::{ConsoleMnemonicEntropyEncoder, MnemonicEncoder},
 };
 use crate::{
-    bitcoin::mnemonics::{
-        bip_39,
-        electrum::{
-            self, required_bits_of_entropy_for_mnemonic_length, try_generate_electrum_mnemonic,
-            try_parse_electrum_mnemonic, ElectrumMnemonicLength, ElectrumMnemonicParsingResult,
-            ElectrumMnemonicVersion,
-        },
-    },
+    bitcoin::mnemonics::{electrum, MnemonicFormat},
     console_out::ConsoleOut,
     constants,
     programs::{
@@ -45,7 +38,7 @@ use crate::{
     },
     String16,
 };
-use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use macros::s16;
 
 pub fn get_electrum_mnemonic_program_list<
@@ -60,39 +53,20 @@ pub fn get_electrum_mnemonic_program_list<
 ) -> ProgramListProgram<TProgramSelector, TProgramExitResultHandler> {
     let programs: [Arc<dyn Program>; 3] = [
         Arc::from(ConsoleMnemonicEntropyEncoder::from(
-            electrum::get_available_mnemonic_lengths,
-            s16!("Electrum"),
-            &bip_39::WORD_LIST,
-            s16!("17"),
-            s16!("BIP 39"),
             system_services.clone(),
-            mnemonic_encoder,
+            Encoder,
             s16!("Electrum Entropy Encoder (BIP 39 Words)"),
         )),
         Arc::from(ConsoleMnemonicEntropyDecoder::from(
             s16!("Electrum Mnemonic Bytes"),
-            s16!("Electrum"),
-            &bip_39::WORD_LIST,
-            s16!("BIP 39"),
+            electrum::MnemonicParser,
             system_services.clone(),
-            mnemonic_parser,
-            bip_39::LONGEST_WORD_LENGTH as usize,
             s16!("Electrum Entropy Decoder (BIP 39 Words)"),
-            electrum::MAX_WORD_COUNT,
         )),
         Arc::from(ConsoleMnemonicBip39SeedDeriver::from(
-            electrum::NORMALIZATION_SETTINGS,
-            electrum::MNEMONIC_WORD_SPACING,
-            s16!("Electrum"),
-            &bip_39::WORD_LIST,
-            s16!("BIP 39"),
             system_services.clone(),
-            mnemonic_parser,
-            electrum::EXTENSION_PREFIX,
-            bip_39::LONGEST_WORD_LENGTH as usize,
+            electrum::MnemonicParser,
             s16!("Electrum Mnemonic To BIP 32 Seed (BIP 39 Words)"),
-            electrum::SEED_DERIVATION_PBKDF_ITERATIONS,
-            electrum::MAX_WORD_COUNT,
         )),
     ];
 
@@ -100,99 +74,117 @@ pub fn get_electrum_mnemonic_program_list<
         .as_program(program_selector.clone(), exit_result_handler.clone())
 }
 
-impl ConsoleWriteable for ElectrumMnemonicVersion {
+struct Encoder;
+
+impl MnemonicEncoder for Encoder {
+    type TMnemonicLength = electrum::MnemonicLength;
+
+    fn mnemnonic_format(&self) -> MnemonicFormat<Self::TMnemonicLength> {
+        electrum::MNEMONIC_FORMAT
+    }
+
+    fn try_encode<TSystemServices: SystemServices>(
+        &self,
+        bytes: &[u8],
+        system_services: &TSystemServices,
+        mnemonic_length: Self::TMnemonicLength,
+    ) -> Result<Vec<String16<'static>>, Option<String16<'static>>> {
+        // User must select a mnemonic version; allow either Segwit or Legacy.
+        let mut mnemonic_version_list = ConsoleUiList::from(
+            ConsoleUiTitle::from(s16!(" Mnemonic Version "), constants::SMALL_TITLE),
+            constants::SELECT_LIST,
+            &[
+                electrum::MnemonicVersion::Segwit,
+                electrum::MnemonicVersion::Legacy,
+            ][..],
+        );
+
+        let console = system_services.get_console_out();
+        let mnemonic_version_selection_label =
+            ConsoleUiLabel::from(s16!("Type of Electrum Mnemonic"));
+        let mnemonic_version = loop {
+            mnemonic_version_selection_label.write_to(&console);
+            match mnemonic_version_list.prompt_for_selection(system_services) {
+                Some((v, _, _)) => break *v,
+                None => {
+                    // User cancelled; do we want to exit mnemonic generation?
+                    if ConsoleUiConfirmationPrompt::from(system_services)
+                        .prompt_for_confirmation(s16!("Cancel Electrum Mnemonic Generation?"))
+                    {
+                        return Err(None);
+                    }
+                }
+            }
+        };
+
+        // We've selected a mnemonic version, so generate the mnemonic.
+        match electrum::try_generate_mnemonic(bytes, mnemonic_length, mnemonic_version) {
+            Ok((m, i)) => {
+                if i > 0 {
+                    // We had to increment the entropy, so extracted entropy will be input + i.
+                    console
+                        .line_start()
+                        .new_line()
+                        .in_colours(constants::WARNING_COLOURS, |c| {
+                            c.output_utf16(s16!(
+                                "Mnemonic generation required incrementing entropy by "
+                            ))
+                            .output_utf32(&format!("{}\0", i))
+                            .output_utf16_line(s16!("."))
+                        });
+                }
+
+                // Return the mnemonic.
+                Ok(m)
+            }
+
+            // Return the error message we got when generating the mnemonic.
+            Err(e) => Err(Some(e)),
+        }
+    }
+}
+
+impl ConsoleWriteable for electrum::MnemonicVersion {
     fn write_to<T: ConsoleOut>(&self, console: &T) {
         console.output_utf16((*self).into());
     }
 }
 
-fn mnemonic_encoder<TSystemServices: SystemServices>(
-    system_services: &TSystemServices,
-    mnemonic_length: ElectrumMnemonicLength,
-    bytes: &[u8],
-) -> Result<Vec<String16<'static>>, Option<String16<'static>>> {
-    // User must select a mnemonic version; allow either Segwit or Legacy.
-    let mut mnemonic_version_list = ConsoleUiList::from(
-        ConsoleUiTitle::from(s16!(" Mnemonic Version "), constants::SMALL_TITLE),
-        constants::SELECT_LIST,
-        &[
-            ElectrumMnemonicVersion::Segwit,
-            ElectrumMnemonicVersion::Legacy,
-        ][..],
-    );
-
-    let console = system_services.get_console_out();
-    let mnemonic_version_selection_label = ConsoleUiLabel::from(s16!("Type of Electrum Mnemonic"));
-    let mnemonic_version = loop {
-        mnemonic_version_selection_label.write_to(&console);
-        match mnemonic_version_list.prompt_for_selection(system_services) {
-            Some((v, _, _)) => break *v,
-            None => {
-                // User cancelled; do we want to exit mnemonic generation?
-                if ConsoleUiConfirmationPrompt::from(system_services)
-                    .prompt_for_confirmation(s16!("Cancel Electrum Mnemonic Generation?"))
-                {
-                    return Err(None);
-                }
-            }
-        }
-    };
-
-    // We've selected a mnemonic version, so generate the mnemonic.
-    match try_generate_electrum_mnemonic(bytes, mnemonic_length, mnemonic_version) {
-        Ok((m, i)) => {
-            if i > 0 {
-                // We had to increment the entropy, so extracted entropy will be input + i.
-                console
-                    .line_start()
-                    .new_line()
-                    .in_colours(constants::WARNING_COLOURS, |c| {
-                        c.output_utf16(s16!(
-                            "Mnemonic generation required incrementing entropy by "
-                        ))
-                        .output_utf32(&format!("{}\0", i))
-                        .output_utf16_line(s16!("."))
-                    });
-            }
-
-            // Return the mnemonic.
-            Ok(m)
-        }
-
-        // Return the error message we got when generating the mnemonic.
-        Err(e) => Err(Some(e)),
+impl ConsoleWriteable for electrum::MnemonicLength {
+    fn write_to<T: ConsoleOut>(&self, console: &T) {
+        super::write_mnemonic_length_to(
+            (*self).into(),
+            electrum::required_bits_of_entropy_for_mnemonic_length(*self),
+            console,
+        );
     }
 }
 
-fn mnemonic_parser(words: &Vec<String16<'static>>) -> ElectrumMnemonicParsingResult<'static> {
-    try_parse_electrum_mnemonic(&words)
-}
-
-impl<'a> ConsoleWriteable for ElectrumMnemonicParsingResult<'a> {
+impl<'a> ConsoleWriteable for electrum::MnemonicParsingResult<'a> {
     fn write_to<T: ConsoleOut>(&self, console: &T) {
         match self {
-            ElectrumMnemonicParsingResult::InvalidLength => console
+            electrum::MnemonicParsingResult::InvalidLength => console
                 .in_colours(constants::ERROR_COLOURS, |c| {
                     c.output_utf16(s16!("Invalid Length"))
                 }),
-            ElectrumMnemonicParsingResult::InvalidWordEncountered(_, w, _) => console
+            electrum::MnemonicParsingResult::InvalidWordEncountered(_, w, _) => console
                 .in_colours(constants::ERROR_COLOURS, |c| {
                     c.output_utf16(s16!("Invalid word: ")).output_utf16(*w)
                 }),
-            ElectrumMnemonicParsingResult::OldFormat(length, _) => {
+            electrum::MnemonicParsingResult::OldFormat(length, _) => {
                 console.in_colours(constants::WARNING_COLOURS, |c| {
                     c.output_utf16((*length).into())
                         .output_utf16(s16!(" Mnemonic is old Electrum mnemonic format."))
                 })
             }
-            ElectrumMnemonicParsingResult::InvalidVersion(length, _, version_bytes) => console
+            electrum::MnemonicParsingResult::InvalidVersion(length, _, version_bytes) => console
                 .in_colours(constants::WARNING_COLOURS, |c| {
                     c.output_utf16((*length).into())
                         .output_utf16(s16!(" Mnemonic has invalid version bytes: "))
                         .output_utf32(&format!("{:?}\0", version_bytes))
                         .output_utf16(s16!("."))
                 }),
-            ElectrumMnemonicParsingResult::Bip39(length, _, version) => {
+            electrum::MnemonicParsingResult::Bip39(length, _, version) => {
                 console.in_colours(constants::WARNING_COLOURS, |c| {
                     c.output_utf16((*length).into())
                         .output_utf16(s16!(" Mnemonic with version: '"))
@@ -200,7 +192,7 @@ impl<'a> ConsoleWriteable for ElectrumMnemonicParsingResult<'a> {
                         .output_utf16(s16!("' is a BIP 39 mnemonic."))
                 })
             }
-            ElectrumMnemonicParsingResult::Valid(length, _, version) => {
+            electrum::MnemonicParsingResult::Valid(length, _, version) => {
                 console.in_colours(constants::SUCCESS_COLOURS, |c| {
                     c.output_utf16((*length).into())
                         .output_utf16(s16!(" Mnemonic with version: '"))
@@ -209,49 +201,5 @@ impl<'a> ConsoleWriteable for ElectrumMnemonicParsingResult<'a> {
                 })
             }
         };
-    }
-}
-
-impl<'a> MnemonicByteParseResult for ElectrumMnemonicParsingResult<'a> {
-    fn get_bytes(self) -> Option<Box<[u8]>> {
-        match self {
-            ElectrumMnemonicParsingResult::InvalidVersion(_, bytes, _) => Some(bytes),
-            ElectrumMnemonicParsingResult::OldFormat(_, bytes) => Some(bytes),
-            ElectrumMnemonicParsingResult::Bip39(_, bytes, _) => Some(bytes),
-            ElectrumMnemonicParsingResult::Valid(_, bytes, _) => Some(bytes),
-            _ => None,
-        }
-    }
-
-    fn can_get_bytes(&self) -> bool {
-        match self {
-            ElectrumMnemonicParsingResult::InvalidVersion(..) => true,
-            ElectrumMnemonicParsingResult::OldFormat(..) => true,
-            ElectrumMnemonicParsingResult::Bip39(..) => true,
-            ElectrumMnemonicParsingResult::Valid(..) => true,
-            _ => false,
-        }
-    }
-}
-
-impl<'a> MnemonicSeedDeriveResult for ElectrumMnemonicParsingResult<'a> {
-    fn can_derive_seed(&self) -> bool {
-        match self {
-            ElectrumMnemonicParsingResult::Valid(..) => true,
-            _ => false,
-        }
-    }
-}
-
-impl ConsoleWriteable for ElectrumMnemonicLength {
-    fn write_to<T: ConsoleOut>(&self, console: &T) {
-        console
-            .output_utf16((*self).into())
-            .output_utf16(s16!(" ("))
-            .output_utf32(&format!(
-                "{}\0",
-                required_bits_of_entropy_for_mnemonic_length(*self)
-            ))
-            .output_utf16(s16!(" bits)"));
     }
 }

--- a/bst/src/programs/console/entropy/mnemonics/mnemonic_bip_32_seed_deriver.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mnemonic_bip_32_seed_deriver.rs
@@ -1,0 +1,155 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    bitcoin::mnemonics::{derive_hd_wallet_seed, ExtensionPhraseNormalizationSettings},
+    clipboard::ClipboardEntry,
+    console_out::ConsoleOut,
+    constants,
+    programs::{console::write_bytes, Program, ProgramExitResult},
+    system_services::SystemServices,
+    ui::console::{
+        get_mnemonic_input, prompt_for_clipboard_write, ConsoleUiTitle, ConsoleWriteable,
+    },
+    String16,
+};
+use alloc::vec::Vec;
+use macros::s16;
+
+pub trait MnemonicSeedDeriveResult: ConsoleWriteable {
+    fn can_derive_seed(&self) -> bool;
+}
+
+pub struct ConsoleMnemonicBip39SeedDeriver<
+    TSystemServices: SystemServices,
+    TMnemonicParseResult: MnemonicSeedDeriveResult,
+    FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
+> {
+    normalization_settings: ExtensionPhraseNormalizationSettings,
+    mnemonic_word_spacing: String16<'static>,
+    mnemonic_format_name: String16<'static>,
+    word_list: &'static [String16<'static>],
+    word_list_name: String16<'static>,
+    system_services: TSystemServices,
+    mnemonic_parser: FMnemonicParser,
+    extension_prefix: &'static [u8],
+    longest_word_length: usize,
+    name: String16<'static>,
+    pbkdf_iterations: u32,
+    max_words: usize,
+}
+
+impl<
+        TSystemServices: SystemServices,
+        TMnemonicParseResult: MnemonicSeedDeriveResult,
+        FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
+    > ConsoleMnemonicBip39SeedDeriver<TSystemServices, TMnemonicParseResult, FMnemonicParser>
+{
+    pub const fn from(
+        normalization_settings: ExtensionPhraseNormalizationSettings,
+        mnemonic_word_spacing: String16<'static>,
+        mnemonic_format_name: String16<'static>,
+        word_list: &'static [String16<'static>],
+        word_list_name: String16<'static>,
+        system_services: TSystemServices,
+        mnemonic_parser: FMnemonicParser,
+        extension_prefix: &'static [u8],
+        longest_word_length: usize,
+        name: String16<'static>,
+        pbkdf_iterations: u32,
+        max_words: usize,
+    ) -> Self {
+        Self {
+            normalization_settings,
+            mnemonic_word_spacing,
+            mnemonic_format_name,
+            longest_word_length,
+            extension_prefix,
+            pbkdf_iterations,
+            system_services,
+            mnemonic_parser,
+            word_list_name,
+            word_list,
+            max_words,
+            name,
+        }
+    }
+}
+
+impl<
+        TSystemServices: SystemServices,
+        TMnemonicParseResult: MnemonicSeedDeriveResult,
+        FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
+    > Program
+    for ConsoleMnemonicBip39SeedDeriver<TSystemServices, TMnemonicParseResult, FMnemonicParser>
+{
+    fn name(&self) -> String16<'static> {
+        self.name
+    }
+
+    fn run(&self) -> ProgramExitResult {
+        let console = self.system_services.get_console_out();
+        console.clear();
+
+        ConsoleUiTitle::from(self.name(), constants::BIG_TITLE).write_to(&console);
+        console
+            .output_utf16(s16!(
+                "This program derives a BIP 32 HD wallet seed from from the "
+            ))
+            .output_utf16(self.mnemonic_format_name)
+            .output_utf16(s16!(" Mnemonic Format utilizing the "))
+            .output_utf16(self.word_list_name)
+            .output_utf16_line(s16!(" word list."));
+
+        let mnemonic_input_result = get_mnemonic_input::<_, TMnemonicParseResult, _, _>(
+            |r| r.can_derive_seed(),
+            &self.system_services,
+            &self.mnemonic_parser,
+            self.word_list,
+            5,
+            self.longest_word_length,
+            self.max_words,
+        );
+
+        match mnemonic_input_result {
+            Some((mnemonic, _)) => {
+                let mut derived_seed = derive_hd_wallet_seed(
+                    self.normalization_settings,
+                    mnemonic,
+                    self.mnemonic_word_spacing,
+                    Vec::new(), // TODO
+                    self.extension_prefix,
+                    self.pbkdf_iterations,
+                );
+
+                write_bytes(
+                    &self.system_services,
+                    s16!("BIP 32 HD Wallet Seed"),
+                    &derived_seed,
+                );
+
+                prompt_for_clipboard_write(
+                    &self.system_services,
+                    ClipboardEntry::Bytes(s16!("BIP 32 HD Wallet Seed"), derived_seed[..].into()),
+                );
+
+                derived_seed.fill(0);
+                ProgramExitResult::Success
+            }
+            None => ProgramExitResult::UserCancelled,
+        }
+    }
+}

--- a/bst/src/programs/console/entropy/mnemonics/mnemonic_bip_32_seed_deriver.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mnemonic_bip_32_seed_deriver.rs
@@ -15,14 +15,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    bitcoin::mnemonics::{derive_hd_wallet_seed, ExtensionPhraseNormalizationSettings},
+    bitcoin::mnemonics::{
+        allow_extension_phrase_character, derive_hd_wallet_seed,
+        ExtensionPhraseNormalizationSettings,
+    },
     clipboard::ClipboardEntry,
     console_out::ConsoleOut,
     constants,
     programs::{console::write_bytes, Program, ProgramExitResult},
     system_services::SystemServices,
     ui::console::{
-        get_mnemonic_input, prompt_for_clipboard_write, ConsoleUiTitle, ConsoleWriteable,
+        get_mnemonic_input, prompt_for_clipboard_write, text_input_paste_handler, ConsoleUiTextBox,
+        ConsoleUiTitle, ConsoleWriteable,
     },
     String16,
 };
@@ -130,7 +134,14 @@ impl<
                     self.normalization_settings,
                     mnemonic,
                     self.mnemonic_word_spacing,
-                    Vec::new(), // TODO
+                    ConsoleUiTextBox::from(&self.system_services, constants::TEXT_INPUT)
+                        .get_text_input(
+                            console.size().width(),
+                            text_input_paste_handler,
+                            s16!("Extension Phrase"),
+                            s16!(" Text "),
+                            Some(allow_extension_phrase_character),
+                        ),
                     self.extension_prefix,
                     self.pbkdf_iterations,
                 );

--- a/bst/src/programs/console/entropy/mnemonics/mnemonic_entropy_decoder.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mnemonic_entropy_decoder.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
+    bitcoin::mnemonics::{MnemonicParseResult, MnemonicParser},
     clipboard::ClipboardEntry,
     console_out::ConsoleOut,
     constants,
@@ -25,68 +26,40 @@ use crate::{
     },
     String16,
 };
-use alloc::{boxed::Box, vec::Vec};
 use macros::s16;
 
-pub trait MnemonicByteParseResult: ConsoleWriteable {
-    fn get_bytes(self) -> Option<Box<[u8]>>;
-
-    fn can_get_bytes(&self) -> bool;
-}
-
 pub struct ConsoleMnemonicEntropyDecoder<
+    TMnemonicParser: MnemonicParser,
     TSystemServices: SystemServices,
-    TMnemonicParseResult: MnemonicByteParseResult,
-    FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
 > {
     clipboard_entry_name: String16<'static>,
-    mnemonic_format_name: String16<'static>,
-    word_list: &'static [String16<'static>],
-    word_list_name: String16<'static>,
+    mnemonic_parser: TMnemonicParser,
     system_services: TSystemServices,
-    mnemonic_parser: FMnemonicParser,
-    longest_word_length: usize,
     name: String16<'static>,
-    max_words: usize,
 }
 
-impl<
-        TSystemServices: SystemServices,
-        TMnemonicParseResult: MnemonicByteParseResult,
-        FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
-    > ConsoleMnemonicEntropyDecoder<TSystemServices, TMnemonicParseResult, FMnemonicParser>
+impl<TMnemonicParser: MnemonicParser, TSystemServices: SystemServices>
+    ConsoleMnemonicEntropyDecoder<TMnemonicParser, TSystemServices>
 {
     pub const fn from(
         clipboard_entry_name: String16<'static>,
-        mnemonic_format_name: String16<'static>,
-        word_list: &'static [String16<'static>],
-        word_list_name: String16<'static>,
+        mnemonic_parser: TMnemonicParser,
         system_services: TSystemServices,
-        mnemonic_parser: FMnemonicParser,
-        longest_word_length: usize,
         name: String16<'static>,
-        max_words: usize,
     ) -> Self {
         Self {
             clipboard_entry_name,
-            mnemonic_format_name,
-            longest_word_length,
-            system_services,
             mnemonic_parser,
-            word_list_name,
-            word_list,
-            max_words,
+            system_services,
             name,
         }
     }
 }
 
-impl<
-        TSystemServices: SystemServices,
-        TMnemonicParseResult: MnemonicByteParseResult,
-        FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
-    > Program
-    for ConsoleMnemonicEntropyDecoder<TSystemServices, TMnemonicParseResult, FMnemonicParser>
+impl<TMnemonicParser: MnemonicParser, TSystemServices: SystemServices> Program
+    for ConsoleMnemonicEntropyDecoder<TMnemonicParser, TSystemServices>
+where
+    TMnemonicParser::TParseResult: ConsoleWriteable,
 {
     fn name(&self) -> String16<'static> {
         self.name
@@ -96,12 +69,15 @@ impl<
         let console = self.system_services.get_console_out();
         console.clear();
 
+        let mnemonic_format = self.mnemonic_parser.mnemonic_format();
         ConsoleUiTitle::from(self.name(), constants::BIG_TITLE).write_to(&console);
         console
-            .output_utf16(s16!("This program decodes entropy from the "))
-            .output_utf16(self.mnemonic_format_name)
-            .output_utf16(s16!(" Mnemonic Format utilizing the "))
-            .output_utf16(self.word_list_name)
+            .output_utf16(s16!(
+                "This program decodes entropy from a mnemonic utilizing the "
+            ))
+            .output_utf16(mnemonic_format.name())
+            .output_utf16(s16!(" format, and "))
+            .output_utf16(mnemonic_format.word_list().name())
             .output_utf16_line(s16!(
                 " word list, validates it, and extracts the underlying bytes."
             ))
@@ -111,14 +87,11 @@ impl<
                 ))
             });
 
-        let mnemonic_input_result = get_mnemonic_input::<_, TMnemonicParseResult, _, _>(
+        let mnemonic_input_result = get_mnemonic_input(
             |r| r.can_get_bytes(),
             &self.system_services,
             &self.mnemonic_parser,
-            self.word_list,
             5,
-            self.longest_word_length,
-            self.max_words,
         );
 
         match mnemonic_input_result {

--- a/bst/src/programs/console/entropy/mnemonics/mod.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mod.rs
@@ -15,9 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 mod bip_39;
-mod bip_39_word_list_mnemonic_decoder;
-mod bip_39_word_list_mnemonic_encoder;
 mod electrum;
+mod mnemonic_entropy_decoder;
+mod mnemonic_entropy_encoder;
 
 use crate::{
     programs::{

--- a/bst/src/programs/console/entropy/mnemonics/mod.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mod.rs
@@ -16,6 +16,7 @@
 
 mod bip_39;
 mod electrum;
+mod mnemonic_bip_32_seed_deriver;
 mod mnemonic_entropy_decoder;
 mod mnemonic_entropy_encoder;
 

--- a/bst/src/programs/console/entropy/mnemonics/mod.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mod.rs
@@ -21,14 +21,16 @@ mod mnemonic_entropy_decoder;
 mod mnemonic_entropy_encoder;
 
 use crate::{
+    console_out::ConsoleOut,
     programs::{
         exit_result_handlers::ProgramExitResultHandler,
         program_lists::{ProgramList, ProgramListProgram, ProgramSelector},
         Program,
     },
     system_services::SystemServices,
+    String16,
 };
-use alloc::sync::Arc;
+use alloc::{format, sync::Arc};
 use macros::s16;
 
 pub fn get_entropy_mnemonic_program_list<
@@ -55,4 +57,16 @@ pub fn get_entropy_mnemonic_program_list<
     ];
     ProgramList::from(Arc::from(programs), s16!("Entropy Mnemonic Programs"))
         .as_program(program_selector.clone(), exit_result_handler.clone())
+}
+
+fn write_mnemonic_length_to<T: ConsoleOut>(
+    mnemonic_length_string: String16<'static>,
+    bit_length: usize,
+    console: &T,
+) {
+    console
+        .output_utf16(mnemonic_length_string)
+        .output_utf16(s16!(" ("))
+        .output_utf32(&format!("{}\0", bit_length))
+        .output_utf16(s16!(" bits)"));
 }

--- a/bst/src/programs/exit_result_handlers/console_writing.rs
+++ b/bst/src/programs/exit_result_handlers/console_writing.rs
@@ -20,7 +20,6 @@ use crate::{
     programs::{Program, ProgramExitResult},
     String16,
 };
-use alloc::format;
 use macros::s16;
 
 #[derive(Clone)]
@@ -46,13 +45,6 @@ impl<T: ConsoleOut> ProgramExitResultHandler for ConsoleDumpingProgramExitResult
         match result {
             ProgramExitResult::Success => {}
             ProgramExitResult::UserCancelled => {}
-            ProgramExitResult::BytesError(bytes) => {
-                self.error_prelude(program)
-                    .output_utf32_line(&format!("{:?}\0", bytes));
-            }
-            ProgramExitResult::String8Error(string) => {
-                self.error_prelude(program).output_utf32_line(&string);
-            }
             ProgramExitResult::String16Error(string16) => {
                 self.error_prelude(program)
                     .output_utf16_line(String16::from(&string16));

--- a/bst/src/programs/mod.rs
+++ b/bst/src/programs/mod.rs
@@ -22,13 +22,10 @@ pub mod program_lists;
 use crate::{console_out::ConsoleOut, ui::console::ConsoleWriteable, String16};
 use alloc::{boxed::Box, sync::Arc};
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ProgramExitResult {
     Success,
     UserCancelled,
-    BytesError(Box<[u8]>),
-    String8Error(Box<str>),
     String16Error(Box<[u16]>),
 }
 

--- a/bst/src/string16.rs
+++ b/bst/src/string16.rs
@@ -68,11 +68,11 @@ impl<'a> String16<'a> {
         self.0
     }
 
-    pub fn extend_utf16_vec_with_content(&self, vec: &mut Vec<u16>) {
+    pub fn write_content_to_utf16_vec(&self, vec: &mut Vec<u16>) {
         vec.extend_from_slice(self.content_slice())
     }
 
-    pub fn extend_utf8_vec_with_content(&self, vec: &mut Vec<u8>) {
+    pub fn write_content_to_utf8_vec(&self, vec: &mut Vec<u8>) {
         let mut char_buffer = [0u8; 2];
         for char in decode_utf16(self.content_slice().iter().cloned())
             .filter(|c| c.is_ok())
@@ -90,7 +90,7 @@ impl<'a> String16<'a> {
         self.content_slice().into_iter()
     }
 
-    pub fn content_length_utf8(&self) -> usize {
+    pub fn utf8_content_length(&self) -> usize {
         decode_utf16(self.content_slice().iter().cloned())
             .filter(|c| c.is_ok())
             .map(|c| c.unwrap().len_utf8())

--- a/bst/src/string16.rs
+++ b/bst/src/string16.rs
@@ -14,17 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use alloc::{string::String, vec::Vec};
-use core::{
-    char::decode_utf16,
-    cmp::Ordering,
-    fmt::{self, Debug, Formatter},
-    slice::Iter,
-};
+#[cfg(test)]
+use alloc::string::String;
+use alloc::vec::Vec;
+#[cfg(test)]
+use core::fmt::{self, Debug, Formatter};
+use core::{char::decode_utf16, cmp::Ordering, slice::Iter};
 
 #[derive(Clone, Copy)]
 pub struct String16<'a>(&'a [u16]);
 
+#[cfg(test)]
 impl Debug for String16<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_tuple("String16")
@@ -74,7 +74,7 @@ impl<'a> String16<'a> {
 
     pub fn extend_utf8_vec_with_content(&self, vec: &mut Vec<u8>) {
         let mut char_buffer = [0u8; 2];
-        for char in decode_utf16(self.0.iter().cloned())
+        for char in decode_utf16(self.content_slice().iter().cloned())
             .filter(|c| c.is_ok())
             .map(|c| c.unwrap())
         {
@@ -91,7 +91,7 @@ impl<'a> String16<'a> {
     }
 
     pub fn content_length_utf8(&self) -> usize {
-        decode_utf16(self.0.iter().cloned())
+        decode_utf16(self.content_slice().iter().cloned())
             .filter(|c| c.is_ok())
             .map(|c| c.unwrap().len_utf8())
             .sum()

--- a/bst/src/tests/bitcoin/mnemonics/bip_39.rs
+++ b/bst/src/tests/bitcoin/mnemonics/bip_39.rs
@@ -59,7 +59,14 @@ impl TestVector {
     }
 }
 
-const TEST_VECTORS: [TestVector; 25] = [
+const TEST_VECTORS: [TestVector; 26] = [
+    TestVector::from(
+        s16!(""),
+        &hex!("00000000000000000000000000000000"),
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        &hex!("5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4"),
+        // "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF",
+    ),
     TestVector::from(
         s16!("TREZOR"),
         &hex!("00000000000000000000000000000000"),
@@ -275,7 +282,7 @@ fn mnemonics_are_generated_from_bytes_correctly() {
                     derive_hd_wallet_seed(
                         bip_39::NORMALIZATION_SETTINGS,
                         mnemonic,
-                        s16!(" "),
+                        bip_39::MNEMONIC_WORD_SPACING,
                         extension_vec,
                         bip_39::EXTENSION_PREFIX,
                         bip_39::SEED_DERIVATION_PBKDF_ITERATIONS

--- a/bst/src/tests/bitcoin/mnemonics/bip_39.rs
+++ b/bst/src/tests/bitcoin/mnemonics/bip_39.rs
@@ -15,13 +15,17 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    bitcoin::mnemonics::bip_39::{
-        try_generate_bip_39_mnemonic, try_parse_bip39_mnemonic, Bip39MnemonicLength,
-        Bip39MnemonicParsingResult, LONGEST_WORD_LENGTH, WORD_LIST,
+    bitcoin::mnemonics::{
+        bip_39::{
+            self, try_generate_bip_39_mnemonic, try_parse_bip39_mnemonic, Bip39MnemonicLength,
+            Bip39MnemonicParsingResult, LONGEST_WORD_LENGTH, WORD_LIST,
+        },
+        derive_hd_wallet_seed,
     },
     String16,
 };
 use hex_literal::hex;
+use macros::s16;
 
 #[test]
 fn longest_word_length_is_correct() {
@@ -33,200 +37,203 @@ fn longest_word_length_is_correct() {
 
 #[derive(Debug)]
 struct TestVector {
-    _extension_phrase: &'static str,
+    extension_phrase: String16<'static>,
     bytes: &'static [u8],
     mnemonic: &'static str,
+    expected_seed: &'static [u8],
 }
 
 impl TestVector {
     pub const fn from(
-        extension_phrase: &'static str,
+        extension_phrase: String16<'static>,
         bytes: &'static [u8],
-        expected_mnemonic: &'static str,
+        mnemonic: &'static str,
+        expected_seed: &'static [u8],
     ) -> Self {
         Self {
-            _extension_phrase: extension_phrase,
+            extension_phrase,
+            expected_seed,
+            mnemonic,
             bytes,
-            mnemonic: expected_mnemonic,
         }
     }
 }
 
 const TEST_VECTORS: [TestVector; 25] = [
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("00000000000000000000000000000000"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-        // "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+        &hex!("c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04"),
         // "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
         "legal winner thank year wave sausage worth useful legal winner thank yellow",
-        // "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
+        &hex!("2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607"),
         // "xprv9s21ZrQH143K2gA81bYFHqU68xz1cX2APaSq5tt6MFSLeXnCKV1RVUJt9FWNTbrrryem4ZckN8k4Ls1H6nwdvDTvnV7zEXs2HgPezuVccsq",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("80808080808080808080808080808080"),
         "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-        // "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
+        &hex!("d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8"),
         // "xprv9s21ZrQH143K2shfP28KM3nr5Ap1SXjz8gc2rAqqMEynmjt6o1qboCDpxckqXavCwdnYds6yBHZGKHv7ef2eTXy461PXUjBFQg6PrwY4Gzq",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("ffffffffffffffffffffffffffffffff"),
         "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-        // "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
+        &hex!("ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069"),
         // "xprv9s21ZrQH143K2V4oox4M8Zmhi2Fjx5XK4Lf7GKRvPSgydU3mjZuKGCTg7UPiBUD7ydVPvSLtg9hjp7MQTYsW67rZHAXeccqYqrsx8LcXnyd",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("000000000000000000000000000000000000000000000000"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
-        // "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
+        &hex!("035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa"),
         // "xprv9s21ZrQH143K3mEDrypcZ2usWqFgzKB6jBBx9B6GfC7fu26X6hPRzVjzkqkPvDqp6g5eypdk6cyhGnBngbjeHTe4LsuLG1cCmKJka5SMkmU",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
         "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
-        // "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
+        &hex!("f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd"),
         // "xprv9s21ZrQH143K3Lv9MZLj16np5GzLe7tDKQfVusBni7toqJGcnKRtHSxUwbKUyUWiwpK55g1DUSsw76TF1T93VT4gz4wt5RM23pkaQLnvBh7",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
         "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
-        // "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
+        &hex!("f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd"),
         // "xprv9s21ZrQH143K3Lv9MZLj16np5GzLe7tDKQfVusBni7toqJGcnKRtHSxUwbKUyUWiwpK55g1DUSsw76TF1T93VT4gz4wt5RM23pkaQLnvBh7",
         // "  \r\t\n \t \r  lEGal winner thank year     wave sausage worth useful \t legal winner thank year wave sausage worth useful legal will  \r\r\t ",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("808080808080808080808080808080808080808080808080"),
         "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
-        // "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
+        &hex!("107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65"),
         // "xprv9s21ZrQH143K3VPCbxbUtpkh9pRG371UCLDz3BjceqP1jz7XZsQ5EnNkYAEkfeZp62cDNj13ZTEVG1TEro9sZ9grfRmcYWLBhCocViKEJae",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("ffffffffffffffffffffffffffffffffffffffffffffffff"),
         "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
-        // "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
+        &hex!("0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528"),
         // "xprv9s21ZrQH143K36Ao5jHRVhFGDbLP6FCx8BEEmpru77ef3bmA928BxsqvVM27WnvvyfWywiFN8K6yToqMaGYfzS6Db1EHAXT5TuyCLBXUfdm",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("0000000000000000000000000000000000000000000000000000000000000000"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-        // "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+        &hex!("bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8"),
         // "xprv9s21ZrQH143K32qBagUJAMU2LsHg3ka7jqMcV98Y7gVeVyNStwYS3U7yVVoDZ4btbRNf4h6ibWpY22iRmXq35qgLs79f312g2kj5539ebPM",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
         "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
-        // "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
+        &hex!("bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87"),
         // "xprv9s21ZrQH143K3Y1sd2XVu9wtqxJRvybCfAetjUrMMco6r3v9qZTBeXiBZkS8JxWbcGJZyio8TrZtm6pkbzG8SYt1sxwNLh3Wx7to5pgiVFU",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("8080808080808080808080808080808080808080808080808080808080808080"),
         "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
-        // "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
+        &hex!("c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f"),
         // "xprv9s21ZrQH143K3CSnQNYC3MqAAqHwxeTLhDbhF43A4ss4ciWNmCY9zQGvAKUSqVUf2vPHBTSE1rB2pg4avopqSiLVzXEU8KziNnVPauTqLRo",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
         "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
-        // "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
+        &hex!("dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad"),
         // "xprv9s21ZrQH143K2WFF16X85T2QCpndrGwx6GueB72Zf3AHwHJaknRXNF37ZmDrtHrrLSHvbuRejXcnYxoZKvRquTPyp2JiNG3XcjQyzSEgqCB",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("9e885d952ad362caeb4efe34a8e91bd2"),
         "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
-        // "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
+        &hex!("274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028"),
         // "xprv9s21ZrQH143K2oZ9stBYpoaZ2ktHj7jLz7iMqpgg1En8kKFTXJHsjxry1JbKH19YrDTicVwKPehFKTbmaxgVEc5TpHdS1aYhB2s9aFJBeJH",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("6610b25967cdcca9d59875f5cb50b0ea75433311869e930b"),
         "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
-        // "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
+        &hex!("628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac"),
         // "xprv9s21ZrQH143K3uT8eQowUjsxrmsA9YUuQQK1RLqFufzybxD6DH6gPY7NjJ5G3EPHjsWDrs9iivSbmvjc9DQJbJGatfa9pv4MZ3wjr8qWPAK",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c"),
         "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
-        // "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
+        &hex!("64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440"),
         // "xprv9s21ZrQH143K2XTAhys3pMNcGn261Fi5Ta2Pw8PwaVPhg3D8DWkzWQwjTJfskj8ofb81i9NP2cUNKxwjueJHHMQAnxtivTA75uUFqPFeWzk",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("c0ba5a8e914111210f2bd131f3d5e08d"),
         "scheme spot photo card baby mountain device kick cradle pact join borrow",
-        // "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
+        &hex!("ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612"),
         // "xprv9s21ZrQH143K3FperxDp8vFsFycKCRcJGAFmcV7umQmcnMZaLtZRt13QJDsoS5F6oYT6BB4sS6zmTmyQAEkJKxJ7yByDNtRe5asP2jFGhT6",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3"),
         "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
-        // "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
+        &hex!("fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d"),
         // "xprv9s21ZrQH143K3R1SfVZZLtVbXEB9ryVxmVtVMsMwmEyEvgXN6Q84LKkLRmf4ST6QrLeBm3jQsb9gx1uo23TS7vo3vAkZGZz71uuLCcywUkt",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863"),
         "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
-        // "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
+        &hex!("72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d"),
         // "xprv9s21ZrQH143K2WNnKmssvZYM96VAr47iHUQUTUyUXH3sAGNjhJANddnhw3i3y3pBbRAVk5M5qUGFr4rHbEWwXgX4qrvrceifCYQJbbFDems",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("23db8160a31d3e0dca3688ed941adbf3"),
         "cat swing flag economy stadium alone churn speed unique patch report train",
-        // "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
+        &hex!("deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5"),
         // "xprv9s21ZrQH143K4G28omGMogEoYgDQuigBo8AFHAGDaJdqQ99QKMQ5J6fYTMfANTJy6xBmhvsNZ1CJzRZ64PWbnTFUn6CDV2FxoMDLXdk95DQ",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0"),
         "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
-        // "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
+        &hex!("4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02"),
         // "xprv9s21ZrQH143K3wtsvY8L2aZyxkiWULZH4vyQE5XkHTXkmx8gHo6RUEfH3Jyr6NwkJhvano7Xb2o6UqFKWHVo5scE31SGDCAUsgVhiUuUDyh",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad"),
         "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
-        // "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
+        &hex!("26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d"),
         // "xprv9s21ZrQH143K3rEfqSM4QZRVmiMuSWY9wugscmaCjYja3SbUD3KPEB1a7QXJoajyR2T1SiXU7rFVRXMV9XdYVSZe7JoUXdP4SRHTxsT1nzm",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("f30f8c1da665478f49b001d94c5fc452"),
         "vessel ladder alter error federal sibling chat ability sun glass valve picture",
-        // "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
+        &hex!("2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f"),
         // "xprv9s21ZrQH143K2QWV9Wn8Vvs6jbqfF1YbTCdURQW9dLFKDovpKaKrqS3SEWsXCu6ZNky9PSAENg6c9AQYHcg4PjopRGGKmdD313ZHszymnps",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05"),
         "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
-        // "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
+        &hex!("7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88"),
         // "xprv9s21ZrQH143K4aERa2bq7559eMCCEs2QmmqVjUuzfy5eAeDX4mqZffkYwpzGQRE2YEEeLVRoH4CSHxianrFaVnMN2RYaPUZJhJx8S5j6puX",
     ),
     TestVector::from(
-        "TREZOR",
+        s16!("TREZOR"),
         &hex!("f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f"),
         "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
-        // "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
+        &hex!("01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998"),
         // "xprv9s21ZrQH143K39rnQJknpH1WEPFJrzmAqqasiDcVrNuk926oizzJDDQkdiTvNPr2FYDYzWgiMiC63YmfPAa2oPyNB23r2g7d1yiK6WpqaQS",
     ),
 ];
@@ -261,6 +268,18 @@ fn mnemonics_are_generated_from_bytes_correctly() {
                         .collect::<Vec<String>>()
                         .join(" "),
                     test_vector.mnemonic
+                );
+
+                let mut mut_extension = test_vector.extension_phrase.content_slice().to_vec();
+                assert_eq!(
+                    derive_hd_wallet_seed(
+                        mnemonic,
+                        s16!(" "),
+                        bip_39::EXTENSION_PREFIX,
+                        &mut mut_extension,
+                        bip_39::SEED_DERIVATION_PBKDF_ITERATIONS
+                    ),
+                    test_vector.expected_seed
                 )
             }
             _ => panic!(

--- a/bst/src/tests/bitcoin/mnemonics/bip_39.rs
+++ b/bst/src/tests/bitcoin/mnemonics/bip_39.rs
@@ -270,13 +270,14 @@ fn mnemonics_are_generated_from_bytes_correctly() {
                     test_vector.mnemonic
                 );
 
-                let mut mut_extension = test_vector.extension_phrase.content_slice().to_vec();
+                let extension_vec = test_vector.extension_phrase.content_slice().to_vec();
                 assert_eq!(
                     derive_hd_wallet_seed(
+                        bip_39::NORMALIZATION_SETTINGS,
                         mnemonic,
                         s16!(" "),
+                        extension_vec,
                         bip_39::EXTENSION_PREFIX,
-                        &mut mut_extension,
                         bip_39::SEED_DERIVATION_PBKDF_ITERATIONS
                     ),
                     test_vector.expected_seed

--- a/bst/src/tests/bitcoin/mnemonics/electrum.rs
+++ b/bst/src/tests/bitcoin/mnemonics/electrum.rs
@@ -14,23 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    bitcoin::mnemonics::{
-        bip_39, derive_hd_wallet_seed,
-        electrum::{
-            self, try_generate_electrum_mnemonic, try_parse_electrum_mnemonic,
-            ElectrumMnemonicLength, ElectrumMnemonicParsingResult, ElectrumMnemonicVersion,
-        },
-    },
-    String16,
-};
+use crate::{bitcoin::mnemonics::electrum, String16};
 use hex_literal::hex;
 use macros::s16;
 
 #[derive(Debug)]
 struct TestVector {
     extension_phrase: Option<String16<'static>>,
-    mnemonic_version: ElectrumMnemonicVersion,
+    mnemonic_version: electrum::MnemonicVersion,
     expected_seed: &'static [u8],
     output_bytes: &'static [u8],
     input_bytes: &'static [u8],
@@ -41,7 +32,7 @@ struct TestVector {
 impl TestVector {
     pub const fn from(
         extension_phrase: Option<String16<'static>>,
-        mnemonic_version: ElectrumMnemonicVersion,
+        mnemonic_version: electrum::MnemonicVersion,
         expected_seed: &'static [u8],
         output_bytes: &'static [u8],
         input_bytes: &'static [u8],
@@ -63,7 +54,7 @@ impl TestVector {
 const TEST_VECTORS: [TestVector; 19] = [
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("0000000000000000000000000000000000"),
@@ -72,7 +63,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("0000000000000000000000000000000007"),
@@ -81,7 +72,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("0000000000000000000000000000002811"),
@@ -90,7 +81,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("F000000000000000000000000000002811"),
@@ -99,7 +90,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Legacy,
+        electrum::MnemonicVersion::Legacy,
         &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("0000000000000000000000000000000000"),
@@ -108,7 +99,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Legacy,
+        electrum::MnemonicVersion::Legacy,
         &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("000000000000000000000000000000000a"),
@@ -117,7 +108,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Legacy,
+        electrum::MnemonicVersion::Legacy,
         &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("0000000000000000000000000000000061"),
@@ -126,7 +117,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Legacy,
+        electrum::MnemonicVersion::Legacy,
         &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("E000000000000000000000000000000061"),
@@ -135,7 +126,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("f5feb1a1b5a5bea6afda908f9028c36091782111e557faa1dc0f0483ce4c2127c64e1b7bd213a57b7ad45abb30efdb649b5d8c10326958a5a97a5502c86e7c2b"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEF2A5"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"),
@@ -144,7 +135,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("f5feb1a1b5a5bea6afda908f9028c36091782111e557faa1dc0f0483ce4c2127c64e1b7bd213a57b7ad45abb30efdb649b5d8c10326958a5a97a5502c86e7c2b"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEF2A5"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEF2A5"),
@@ -153,7 +144,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
@@ -162,7 +153,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc383"),
@@ -171,7 +162,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         None,
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("ffb0a779f83feddb0e39aa0dde898cc383"),
@@ -180,7 +171,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         Some(s16!("did you ever hear the tragedy of darth plagueis the wise?")),
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
@@ -189,7 +180,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         Some(s16!("did you ever hear the tragedy of darth plagueis the wise?")),
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc383"),
@@ -198,7 +189,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         Some(s16!("did you ever hear the tragedy of darth plagueis the wise?")),
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("ffb0a779f83feddb0e39aa0dde898cc383"),
@@ -207,7 +198,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         Some(s16!("   DID     \t you ever  \n hear tHe tragedy of darth plagueis the wise?\r\n\t  ")),
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
@@ -216,7 +207,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         Some(s16!("   DID     \t you ever  \n hear tHe tragedy of darth plagueis the wise?\r\n\t  ")),
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc383"),
@@ -225,7 +216,7 @@ const TEST_VECTORS: [TestVector; 19] = [
     ),
     TestVector::from(
         Some(s16!("   DID     \t you ever  \n hear tHe tragedy of darth plagueis the wise?\r\n\t  ")),
-        ElectrumMnemonicVersion::Segwit,
+        electrum::MnemonicVersion::Segwit,
         &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("ffb0a779f83feddb0e39aa0dde898cc383"),
@@ -237,7 +228,6 @@ const TEST_VECTORS: [TestVector; 19] = [
 #[test]
 fn mnemonic_generation_and_parsing() {
     for test_vector in TEST_VECTORS {
-        println!("{}", test_vector.mnemonic);
         let words = test_vector
             .mnemonic
             .split(|c: char| c.is_whitespace())
@@ -251,11 +241,11 @@ fn mnemonic_generation_and_parsing() {
             .collect::<Vec<String16>>();
 
         let mnemonic_length = match words.len() {
-            12 => ElectrumMnemonicLength::Twelve,
-            15 => ElectrumMnemonicLength::Fifteen,
-            18 => ElectrumMnemonicLength::Eighteen,
-            21 => ElectrumMnemonicLength::TwentyOne,
-            24 => ElectrumMnemonicLength::TwentyFour,
+            12 => electrum::MnemonicLength::Twelve,
+            15 => electrum::MnemonicLength::Fifteen,
+            18 => electrum::MnemonicLength::Eighteen,
+            21 => electrum::MnemonicLength::TwentyOne,
+            24 => electrum::MnemonicLength::TwentyFour,
             _ => panic!(
                 "Test vector {:?} has an invalid mnemonic length of {}.",
                 test_vector,
@@ -263,17 +253,17 @@ fn mnemonic_generation_and_parsing() {
             ),
         };
 
-        match try_generate_electrum_mnemonic(
+        match electrum::try_generate_mnemonic(
             test_vector.input_bytes,
             mnemonic_length,
             test_vector.mnemonic_version,
         ) {
-            Ok((w, i)) => {
-                assert_eq!(w, word_strings);
+            Ok((words, i)) => {
+                assert_eq!(words, word_strings);
                 assert_eq!(i, test_vector.iterations);
 
-                match try_parse_electrum_mnemonic(&w) {
-                    ElectrumMnemonicParsingResult::Valid(l, b, v) => {
+                match electrum::try_parse_electrum_mnemonic(&words) {
+                    electrum::MnemonicParsingResult::Valid(l, b, v) => {
                         assert_eq!(l, mnemonic_length);
                         assert_eq!(v, test_vector.mnemonic_version);
                         assert_eq!(&b[..], test_vector.output_bytes);
@@ -284,14 +274,8 @@ fn mnemonic_generation_and_parsing() {
                         };
 
                         assert_eq!(
-                            derive_hd_wallet_seed(
-                                electrum::NORMALIZATION_SETTINGS,
-                                w,
-                                bip_39::MNEMONIC_WORD_SPACING,
-                                extension_vec,
-                                electrum::EXTENSION_PREFIX,
-                                electrum::SEED_DERIVATION_PBKDF_ITERATIONS
-                            ),
+                            electrum::BIP_32_DERIVATION_SETTINGS
+                                .derive_hd_wallet_seed(extension_vec, words),
                             test_vector.expected_seed
                         );
                     }

--- a/bst/src/tests/bitcoin/mnemonics/electrum.rs
+++ b/bst/src/tests/bitcoin/mnemonics/electrum.rs
@@ -15,12 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    bitcoin::mnemonics::{
-        bip_39::Bip39MnemonicLength,
-        electrum::{
-            try_generate_electrum_mnemonic, try_parse_electrum_mnemonic,
-            ElectrumMnemonicParsingResult, ElectrumMnemonicVersion,
-        },
+    bitcoin::mnemonics::electrum::{
+        try_generate_electrum_mnemonic, try_parse_electrum_mnemonic, ElectrumMnemonicLength,
+        ElectrumMnemonicParsingResult, ElectrumMnemonicVersion,
     },
     String16,
 };
@@ -164,11 +161,11 @@ fn mnemonic_generation_and_parsing() {
             .collect::<Vec<String16>>();
 
         let mnemonic_length = match words.len() {
-            12 => Bip39MnemonicLength::Twelve,
-            15 => Bip39MnemonicLength::Fifteen,
-            18 => Bip39MnemonicLength::Eighteen,
-            21 => Bip39MnemonicLength::TwentyOne,
-            24 => Bip39MnemonicLength::TwentyFour,
+            12 => ElectrumMnemonicLength::Twelve,
+            15 => ElectrumMnemonicLength::Fifteen,
+            18 => ElectrumMnemonicLength::Eighteen,
+            21 => ElectrumMnemonicLength::TwentyOne,
+            24 => ElectrumMnemonicLength::TwentyFour,
             _ => panic!(
                 "Test vector {:?} has an invalid mnemonic length of {}.",
                 test_vector,

--- a/bst/src/tests/bitcoin/mnemonics/electrum.rs
+++ b/bst/src/tests/bitcoin/mnemonics/electrum.rs
@@ -15,17 +15,23 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    bitcoin::mnemonics::electrum::{
-        try_generate_electrum_mnemonic, try_parse_electrum_mnemonic, ElectrumMnemonicLength,
-        ElectrumMnemonicParsingResult, ElectrumMnemonicVersion,
+    bitcoin::mnemonics::{
+        derive_hd_wallet_seed,
+        electrum::{
+            self, try_generate_electrum_mnemonic, try_parse_electrum_mnemonic,
+            ElectrumMnemonicLength, ElectrumMnemonicParsingResult, ElectrumMnemonicVersion,
+        },
     },
     String16,
 };
 use hex_literal::hex;
+use macros::s16;
 
 #[derive(Debug)]
 struct TestVector {
+    extension_phrase: Option<String16<'static>>,
     mnemonic_version: ElectrumMnemonicVersion,
+    expected_seed: &'static [u8],
     output_bytes: &'static [u8],
     input_bytes: &'static [u8],
     mnemonic: &'static str,
@@ -34,14 +40,18 @@ struct TestVector {
 
 impl TestVector {
     pub const fn from(
+        extension_phrase: Option<String16<'static>>,
         mnemonic_version: ElectrumMnemonicVersion,
+        expected_seed: &'static [u8],
         output_bytes: &'static [u8],
         input_bytes: &'static [u8],
         mnemonic: &'static str,
         iterations: usize,
     ) -> Self {
         Self {
+            extension_phrase,
             mnemonic_version,
+            expected_seed,
             output_bytes,
             input_bytes,
             iterations,
@@ -50,93 +60,146 @@ impl TestVector {
     }
 }
 
-const TEST_VECTORS: [TestVector; 13] = [
+const TEST_VECTORS: [TestVector; 16] = [
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("0000000000000000000000000000000000"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon absent acquire",
         10257,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("0000000000000000000000000000000007"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon absent acquire",
         10250,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("0000000000000000000000000000002811"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon absent acquire",
         0,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("1747666e9b3d06c0242bd98bea990c8778d8e2e31ec55136b83d42adb36d5eb0df577f2901c38bcab80383ff3239079b71c5530cd97419556b38e7d0544f6f33"),
         &hex!("0000000000000000000000000000002811"),
         &hex!("F000000000000000000000000000002811"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon absent acquire",
         0,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Legacy,
+        &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("0000000000000000000000000000000000"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon around",
         97,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Legacy,
+        &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("000000000000000000000000000000000a"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon around",
         87,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Legacy,
+        &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("0000000000000000000000000000000061"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon around",
         0,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Legacy,
+        &hex!("1ea27b761af2325549fef0edcadc8eae028988b91f3abe94a5a4e549ba7b61dc36c28fa2a55c7191aa0211bced362286f88480ce2e065950985b790c769b9401"),
         &hex!("0000000000000000000000000000000061"),
         &hex!("E000000000000000000000000000000061"),
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon around",
         0,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("f5feb1a1b5a5bea6afda908f9028c36091782111e557faa1dc0f0483ce4c2127c64e1b7bd213a57b7ad45abb30efdb649b5d8c10326958a5a97a5502c86e7c2b"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEF2A5"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"),
         "upon jazz roof tape upon jazz roof tape upon jazz roof tape upon jazz roof tape upon jazz roof tape upon jazz rookie feed",
         951,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("f5feb1a1b5a5bea6afda908f9028c36091782111e557faa1dc0f0483ce4c2127c64e1b7bd213a57b7ad45abb30efdb649b5d8c10326958a5a97a5502c86e7c2b"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEF2A5"),
         &hex!("EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEF2A5"),
         "upon jazz roof tape upon jazz roof tape upon jazz roof tape upon jazz roof tape upon jazz roof tape upon jazz rookie feed",
         0,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         "wild father tree among universe such mobile favorite target dynamic credit identify",
-        0
+        0,
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc383"),
         "wild father tree among universe such mobile favorite target dynamic credit identify",
         1
     ),
     TestVector::from(
+        None,
         ElectrumMnemonicVersion::Segwit,
+        &hex!("aac2a6302e48577ab4b46f23dbae0774e2e62c796f797d0a1b5faeb528301e3064342dafb79069e7c4c6b8c38ae11d7a973bec0d4f70626f8cc5184a8d0b0756"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        &hex!("ffb0a779f83feddb0e39aa0dde898cc383"),
+        "wild father tree among universe such mobile favorite target dynamic credit identify",
+        1
+    ),
+    TestVector::from(
+        Some(s16!("did you ever hear the tragedy of darth plagueis the wise?")),
+        ElectrumMnemonicVersion::Segwit,
+        &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        "wild father tree among universe such mobile favorite target dynamic credit identify",
+        0,
+    ),
+    TestVector::from(
+        Some(s16!("did you ever hear the tragedy of darth plagueis the wise?")),
+        ElectrumMnemonicVersion::Segwit,
+        &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc383"),
+        "wild father tree among universe such mobile favorite target dynamic credit identify",
+        1
+    ),
+    TestVector::from(
+        Some(s16!("did you ever hear the tragedy of darth plagueis the wise?")),
+        ElectrumMnemonicVersion::Segwit,
+        &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
         &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
         &hex!("ffb0a779f83feddb0e39aa0dde898cc383"),
         "wild father tree among universe such mobile favorite target dynamic credit identify",
@@ -187,6 +250,22 @@ fn mnemonic_generation_and_parsing() {
                         assert_eq!(l, mnemonic_length);
                         assert_eq!(v, test_vector.mnemonic_version);
                         assert_eq!(&b[..], test_vector.output_bytes);
+
+                        let mut mut_extension = match test_vector.extension_phrase {
+                            Some(s) => s.content_slice().to_vec(),
+                            None => Vec::new(),
+                        };
+
+                        assert_eq!(
+                            derive_hd_wallet_seed(
+                                w,
+                                s16!(" "),
+                                electrum::EXTENSION_PREFIX,
+                                &mut mut_extension,
+                                electrum::SEED_DERIVATION_PBKDF_ITERATIONS
+                            ),
+                            test_vector.expected_seed
+                        );
                     }
                     _ => panic!("Test vector {:?} failed mnemonic parsing.", test_vector,),
                 }

--- a/bst/src/tests/bitcoin/mnemonics/electrum.rs
+++ b/bst/src/tests/bitcoin/mnemonics/electrum.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     bitcoin::mnemonics::{
-        derive_hd_wallet_seed,
+        bip_39, derive_hd_wallet_seed,
         electrum::{
             self, try_generate_electrum_mnemonic, try_parse_electrum_mnemonic,
             ElectrumMnemonicLength, ElectrumMnemonicParsingResult, ElectrumMnemonicVersion,
@@ -287,7 +287,7 @@ fn mnemonic_generation_and_parsing() {
                             derive_hd_wallet_seed(
                                 electrum::NORMALIZATION_SETTINGS,
                                 w,
-                                s16!(" "),
+                                bip_39::MNEMONIC_WORD_SPACING,
                                 extension_vec,
                                 electrum::EXTENSION_PREFIX,
                                 electrum::SEED_DERIVATION_PBKDF_ITERATIONS

--- a/bst/src/tests/bitcoin/mnemonics/electrum.rs
+++ b/bst/src/tests/bitcoin/mnemonics/electrum.rs
@@ -60,7 +60,7 @@ impl TestVector {
     }
 }
 
-const TEST_VECTORS: [TestVector; 16] = [
+const TEST_VECTORS: [TestVector; 19] = [
     TestVector::from(
         None,
         ElectrumMnemonicVersion::Segwit,
@@ -205,6 +205,33 @@ const TEST_VECTORS: [TestVector; 16] = [
         "wild father tree among universe such mobile favorite target dynamic credit identify",
         1
     ),
+    TestVector::from(
+        Some(s16!("   DID     \t you ever  \n hear tHe tragedy of darth plagueis the wise?\r\n\t  ")),
+        ElectrumMnemonicVersion::Segwit,
+        &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        "wild father tree among universe such mobile favorite target dynamic credit identify",
+        0,
+    ),
+    TestVector::from(
+        Some(s16!("   DID     \t you ever  \n hear tHe tragedy of darth plagueis the wise?\r\n\t  ")),
+        ElectrumMnemonicVersion::Segwit,
+        &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc383"),
+        "wild father tree among universe such mobile favorite target dynamic credit identify",
+        1
+    ),
+    TestVector::from(
+        Some(s16!("   DID     \t you ever  \n hear tHe tragedy of darth plagueis the wise?\r\n\t  ")),
+        ElectrumMnemonicVersion::Segwit,
+        &hex!("4aa29f2aeb0127efb55138ab9e7be83b36750358751906f86c662b21a1ea1370f949e6d1a12fa56d3d93cadda93038c76ac8118597364e46f5156fde6183c82f"),
+        &hex!("0fb0a779f83feddb0e39aa0dde898cc384"),
+        &hex!("ffb0a779f83feddb0e39aa0dde898cc383"),
+        "wild father tree among universe such mobile favorite target dynamic credit identify",
+        1
+    ),
 ];
 
 #[test]
@@ -251,17 +278,18 @@ fn mnemonic_generation_and_parsing() {
                         assert_eq!(v, test_vector.mnemonic_version);
                         assert_eq!(&b[..], test_vector.output_bytes);
 
-                        let mut mut_extension = match test_vector.extension_phrase {
+                        let extension_vec = match test_vector.extension_phrase {
                             Some(s) => s.content_slice().to_vec(),
                             None => Vec::new(),
                         };
 
                         assert_eq!(
                             derive_hd_wallet_seed(
+                                electrum::NORMALIZATION_SETTINGS,
                                 w,
                                 s16!(" "),
+                                extension_vec,
                                 electrum::EXTENSION_PREFIX,
-                                &mut mut_extension,
                                 electrum::SEED_DERIVATION_PBKDF_ITERATIONS
                             ),
                             test_vector.expected_seed

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -360,7 +360,7 @@ fn prompt_for_unsigned_integer<
     }
 }
 
-fn text_input_paste_handler<TSystemServices: SystemServices>(
+pub fn text_input_paste_handler<TSystemServices: SystemServices>(
     clipboard_entry: ClipboardEntry,
     scroll_text: &mut ConsoleUiScrollText,
     system_services: &TSystemServices,

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -28,7 +28,7 @@ use crate::{
     ui::{ConfirmationPrompt, DataInput, DataInputType},
     String16,
 };
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{vec, vec::Vec};
 use macros::s16;
 
 pub fn prompt_for_bytes_from_any_data_type<TSystemServices: SystemServices>(
@@ -49,12 +49,18 @@ pub fn prompt_for_bytes_from_any_data_type<TSystemServices: SystemServices>(
     ) {
         DataInput::Number(number) => Ok(number.take_ownership_of_bytes()),
         DataInput::None => Err(ProgramExitResult::UserCancelled),
-        DataInput::Text(text) => match String::from_utf16(&text) {
-            Ok(s) => Ok(s.into_bytes()),
-            Err(e) => Err(ProgramExitResult::String8Error(
-                format!("Invalid string input: {}\0", e).into(),
-            )),
-        },
+        DataInput::Text(mut text) => {
+            // Build a UTF8 buffer.
+            let s = String16::from(&text);
+            let mut utf8_buffer = Vec::with_capacity(s.content_length_utf8());
+
+            // Write to the UTF8 buffer.
+            s.extend_utf8_vec_with_content(&mut utf8_buffer);
+
+            // Pre-emptively clear the text input.
+            text.fill(0);
+            Ok(utf8_buffer)
+        }
         DataInput::Bytes(bytes) => Ok(bytes),
     }
 }

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -51,11 +51,11 @@ pub fn prompt_for_bytes_from_any_data_type<TSystemServices: SystemServices>(
         DataInput::None => Err(ProgramExitResult::UserCancelled),
         DataInput::Text(mut text) => {
             // Build a UTF8 buffer.
-            let s = String16::from(&text);
-            let mut utf8_buffer = Vec::with_capacity(s.content_length_utf8());
+            let text_string = String16::from(&text);
+            let mut utf8_buffer = Vec::with_capacity(text_string.utf8_content_length());
 
             // Write to the UTF8 buffer.
-            s.extend_utf8_vec_with_content(&mut utf8_buffer);
+            text_string.write_content_to_utf8_vec(&mut utf8_buffer);
 
             // Pre-emptively clear the text input.
             text.fill(0);

--- a/bst/src/ui/console/list.rs
+++ b/bst/src/ui/console/list.rs
@@ -43,7 +43,7 @@ impl ConsoleUiListEntryStyle {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConsoleUiListStyles {
     page_information_highlight_colours: ConsoleColours,
     page_information_base_colours: ConsoleColours,

--- a/bst/src/ui/console/mnemonic_input.rs
+++ b/bst/src/ui/console/mnemonic_input.rs
@@ -100,7 +100,7 @@ pub fn get_mnemonic_input<
     let mut output_result: Option<TMnemonicParseResult>;
     loop {
         // A flag indicating whether the user should be allowed to input more words.
-        let allow_more_words = words.len() < 24;
+        let allow_more_words = words.len() < max_words;
 
         // If there's at least one possible word for input, the first gets stored here.
         let mut completion_word = None;

--- a/bst/src/ui/console/mnemonic_input.rs
+++ b/bst/src/ui/console/mnemonic_input.rs
@@ -161,7 +161,7 @@ where
         }
 
         // Parse the mnemonic input.
-        let parse_result = mnemonic_parser.try_decode_bytes(&words);
+        let parse_result = mnemonic_parser.try_parse_mnemonic(&words);
 
         // Write information about the current mnemonic input.
         console.set_cursor_position(mnemonic_info_position);

--- a/bst/src/ui/console/mnemonic_input.rs
+++ b/bst/src/ui/console/mnemonic_input.rs
@@ -1,0 +1,352 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::{ConsoleUiLabel, ConsoleWriteable};
+use crate::{
+    console_out::ConsoleOut,
+    constants,
+    keyboard_in::{BehaviourKey, Key, KeyboardIn},
+    system_services::SystemServices,
+    ui::Point,
+    String16,
+};
+use alloc::{vec, vec::Vec};
+use macros::{c16, s16};
+
+// Readers beware... This is a fairly complicated UI. I'd recommend checking out some of the other UIs first if you haven't
+// already, to get familiar with how BST UIs are written so the weirder stuff here isn't as hard to 'get'. Definitely at
+// least try USING this UI (mnemonic entropy decoder programs, HD wallet seed generators) before trying to read the code.
+
+pub fn get_mnemonic_input<
+    TSystemServices: SystemServices,
+    TMnemonicParseResult: ConsoleWriteable,
+    FMnemonicAcceptancePredicate: Fn(&TMnemonicParseResult) -> bool,
+    FMnemonicParser: Fn(&Vec<String16<'static>>) -> TMnemonicParseResult,
+>(
+    parse_result_acceptance_predicate: FMnemonicAcceptancePredicate,
+    system_services: &TSystemServices,
+    mnemonic_parser: FMnemonicParser,
+    word_list: &[String16<'static>],
+    possible_word_table_rows: usize,
+    longest_word_length: usize,
+    max_words: usize,
+) -> Option<(Vec<String16<'static>>, TMnemonicParseResult)> {
+    let console = system_services.get_console_out();
+    let console_width = console.size().width();
+
+    // A buffer for input truncation.
+    let mut input_buffer = vec![0u16; max_words * (longest_word_length as usize + 1)];
+
+    // A buffer for the individual mnemonic words.
+    let mut words: Vec<String16> = Vec::with_capacity(max_words);
+
+    // A buffer for inputting mnemonic words one at a time.
+    let mut current_word_buffer = vec![0u16; longest_word_length as usize];
+    let mut current_word_buffer_count = 0;
+
+    // 'Possible word list' dimensions.
+    let words_per_row = console_width / (longest_word_length as usize + 1);
+
+    // Write the input UI structure; entered mnemonic label first.
+    ConsoleUiLabel::from(s16!("Entered Mnemonic")).write_to(&console);
+
+    // Make space for the mnemonic line.
+    console.line_start().new_line();
+
+    // Write the mnemonic info label.
+    ConsoleUiLabel::from(s16!("Mnemonic Information")).write_to(&console);
+
+    // Make space for the status line.
+    console.line_start().new_line();
+
+    // Write the possible words list label.
+    ConsoleUiLabel::from(s16!("Possible Words")).write_to(&console);
+
+    // Make sure we have space to write five rows of possible words.
+    console.line_start();
+    for _ in 0..possible_word_table_rows {
+        console.new_line();
+    }
+
+    // Ensure there's space for the exit message.
+    console.in_colours(constants::PROMPT_COLOURS, |c| {
+        c.output_utf16(s16!("Press ESC to..."))
+    });
+
+    // Calculate positions for UI elements.
+    let end_position = console.cursor().position();
+    let exit_message_position = Point::from(0, end_position.y());
+    let word_list_position = exit_message_position - Point::from(0, possible_word_table_rows);
+    let mnemonic_info_position = word_list_position - Point::from(0, 3);
+    let mnemonic_input_position = mnemonic_info_position - Point::from(0, 3);
+
+    // Get the keyboard input provider.
+    let keyboard_in = system_services.get_keyboard_in();
+
+    // A place to store mnemonic parse results.
+    let mut output_result: Option<TMnemonicParseResult>;
+    loop {
+        // A flag indicating whether the user should be allowed to input more words.
+        let allow_more_words = words.len() < 24;
+
+        // If there's at least one possible word for input, the first gets stored here.
+        let mut completion_word = None;
+
+        // Move the cursor position to the possible word list space.
+        console.set_cursor_position(word_list_position);
+        if allow_more_words {
+            // Get the current word's input so far.
+            let word_buffer_content = &current_word_buffer[..current_word_buffer_count];
+
+            // Work out the possible words given the current word input.
+            let possible_words = word_list
+                .iter()
+                .filter(|w| {
+                    w.content_length() >= current_word_buffer_count
+                        && &w.content_slice()[..current_word_buffer_count] == word_buffer_content
+                })
+                .take(possible_word_table_rows * words_per_row);
+
+            // Track the number of words we've written in the current line.
+            let mut line_word_counter = 0;
+
+            // Write the possible word list.
+            for word in possible_words {
+                let blanking = 9 - word.content_length();
+                match completion_word {
+                    Some(_) => {
+                        console
+                            .output_utf16(word.clone())
+                            .blank_up_to_line_end(blanking);
+                    }
+                    None => {
+                        // Highlight the first word, as that's the one that would be autocompleted on space key press.
+                        console.in_colours(constants::PROMPT_COLOURS, |c| {
+                            c.output_utf16(word.clone()).blank_up_to_line_end(blanking)
+                        });
+
+                        completion_word = Some(word);
+                    }
+                }
+
+                line_word_counter += 1;
+                if words_per_row == line_word_counter {
+                    // Handle any remainder of the screen width.
+                    console.blank_remaining_line();
+                    line_word_counter = 0;
+                }
+            }
+        }
+
+        // Blank any remaining lines in the word list space.
+        while console.cursor().position().y() < end_position.y() {
+            console.blank_remaining_line();
+        }
+
+        // Parse the mnemonic input.
+        let parse_result = (mnemonic_parser)(&words);
+
+        // Write information about the current mnemonic input.
+        console.set_cursor_position(mnemonic_info_position);
+        parse_result.write_to(&console);
+        console.blank_remaining_line();
+
+        // We'll write the exit message now, so go to that position.
+        console.set_cursor_position(exit_message_position);
+
+        // Check whether the calling program would accept the parse result.
+        if (parse_result_acceptance_predicate)(&parse_result) {
+            output_result = Some(parse_result);
+            console.in_colours(constants::PROMPT_COLOURS, |c| {
+                c.output_utf16(s16!("Press ESC to use mnemonic..."))
+            });
+        } else {
+            output_result = None;
+            console.in_colours(constants::PROMPT_COLOURS, |c| {
+                // Trailing spaces as a poor man's blanking for the difference between this and 'Press ESC to use mnemonic...'.
+                c.output_utf16(s16!("Press ESC to cancel...      "))
+            });
+        }
+
+        // Write the current input to the input line buffer.
+        let mut input_buffer_offset = 0;
+        for word in &words {
+            // Get the length of the word.
+            let word_length = word.content_length();
+
+            // Write the word to the buffer.
+            input_buffer[input_buffer_offset..input_buffer_offset + word_length]
+                .copy_from_slice(word.content_slice());
+
+            // Write a space to the buffer.
+            input_buffer[input_buffer_offset + word_length] = c16!(" ");
+
+            // Add the word and space's length to the offset.
+            input_buffer_offset += word_length + 1;
+        }
+
+        if allow_more_words {
+            // If there's space for more words, write the current word buffer to the input buffer.
+            input_buffer[input_buffer_offset..input_buffer_offset + current_word_buffer_count]
+                .copy_from_slice(&current_word_buffer[..current_word_buffer_count]);
+
+            // Update the offset; we want a null at the end, so add an extra 1.
+            input_buffer_offset += current_word_buffer_count + 1;
+        }
+
+        // Fill the remaining buffer with null.
+        input_buffer[input_buffer_offset - 1..].fill(0);
+
+        // Move the cursor to the mnemonic input line.
+        console.set_cursor_position(mnemonic_input_position);
+        console.in_colours(
+            if completion_word.is_none() && current_word_buffer_count > 0 {
+                // There's no possible words, and we've started writing one; the input is bad.
+                constants::ERROR_COLOURS
+            } else {
+                constants::DEFAULT_COLOURS
+            },
+            |c| {
+                if input_buffer_offset > console_width {
+                    // If there's not enough space to write the entire mnemonic, start with an ellipsis.
+                    c.output_utf16(s16!("..."))
+                        // Then write the tail of the input buffer.
+                        .output_utf16(String16::from(
+                            // +4 for ellipsis and a cursor space.
+                            &input_buffer
+                                [input_buffer_offset - console_width + 4..input_buffer_offset],
+                        ))
+                } else {
+                    // If there's enough space to write the entire mnemonic, just write it.
+                    c.output_utf16(String16::from(&input_buffer[..input_buffer_offset]))
+                }
+            },
+        );
+
+        // Get the position where the input ends.
+        let input_cursor_position = console.cursor().position();
+
+        // Blank then go back to the end of the line.
+        console
+            .blank_remaining_line()
+            .set_cursor_position(input_cursor_position);
+
+        // Show the cursor during input.
+        console.set_cursor_visibility(true);
+
+        // A flag indicating whether an exit has been requested.
+        let mut exit = false;
+
+        // Only re-draw when there's some actual change.
+        loop {
+            // Read some input.
+            let key = keyboard_in.read_key();
+
+            // Hide the cursor the rest of the time.
+            console.set_cursor_visibility(false);
+
+            match key.key() {
+                Key::Behaviour(b) => match b {
+                    BehaviourKey::Escape => {
+                        console.set_cursor_position(end_position).line_start();
+                        exit = true;
+                        break;
+                    }
+                    BehaviourKey::BackSpace => {
+                        if current_word_buffer_count > 0 {
+                            // If we've started writing a word, pop the last character.
+                            current_word_buffer[current_word_buffer_count - 1] = 0;
+                            current_word_buffer_count -= 1;
+                            break;
+                        }
+
+                        if words.len() > 0 {
+                            // If we've not started writing a new word, but there are previous words,
+                            // move the previous word into the current word buffer.
+                            let word = words.pop().unwrap();
+                            current_word_buffer_count = word.content_length();
+                            current_word_buffer[..current_word_buffer_count]
+                                .copy_from_slice(word.content_slice());
+                            break;
+                        }
+                    }
+                    _ => {}
+                },
+                Key::Digit(_) => { /* Ignore digits. */ }
+                Key::Symbol(s) => match s {
+                    c16!("a")
+                    | c16!("b")
+                    | c16!("c")
+                    | c16!("d")
+                    | c16!("e")
+                    | c16!("f")
+                    | c16!("g")
+                    | c16!("h")
+                    | c16!("i")
+                    | c16!("j")
+                    | c16!("k")
+                    | c16!("l")
+                    | c16!("m")
+                    | c16!("n")
+                    | c16!("o")
+                    | c16!("p")
+                    | c16!("q")
+                    | c16!("r")
+                    | c16!("s")
+                    | c16!("t")
+                    | c16!("u")
+                    | c16!("v")
+                    | c16!("w")
+                    | c16!("x")
+                    | c16!("y")
+                    | c16!("z") => {
+                        if allow_more_words && current_word_buffer_count < current_word_buffer.len()
+                        {
+                            // If there's space, write the character to the current word buffer.
+                            current_word_buffer[current_word_buffer_count] = s;
+                            current_word_buffer_count += 1;
+                            break;
+                        }
+                    }
+                    c16!(" ") => match completion_word {
+                        Some(w) => {
+                            if allow_more_words {
+                                // Add the word to the word list.
+                                words.push(*w);
+
+                                // Then clear the current word buffer.
+                                current_word_buffer_count = 0;
+                                current_word_buffer.fill(0);
+                                break;
+                            }
+                        }
+                        None => { /* There's no possible word, so don't do anything. */ }
+                    },
+                    _ => { /* Ignore any other symbol input. */ }
+                },
+            }
+        }
+
+        if exit {
+            break;
+        }
+    }
+
+    match output_result {
+        Some(r) => Some((words, r)),
+        None => None,
+    }
+}

--- a/bst/src/ui/console/mod.rs
+++ b/bst/src/ui/console/mod.rs
@@ -32,7 +32,7 @@ pub use confirmation_prompt::ConsoleUiConfirmationPrompt;
 pub use continue_prompt::ConsoleUiContinuePrompt;
 pub use data_input::{
     prompt_for_bytes_from_any_data_type, prompt_for_data_input, prompt_for_u128, prompt_for_u16,
-    prompt_for_u32, prompt_for_u64, prompt_for_u8,
+    prompt_for_u32, prompt_for_u64, prompt_for_u8, text_input_paste_handler,
 };
 pub use label::ConsoleUiLabel;
 pub use list::{ConsoleUiList, ConsoleUiListEntryStyle, ConsoleUiListStyles};

--- a/bst/src/ui/console/mod.rs
+++ b/bst/src/ui/console/mod.rs
@@ -20,6 +20,7 @@ mod continue_prompt;
 mod data_input;
 mod label;
 mod list;
+mod mnemonic_input;
 mod numeric_input;
 mod program_selector;
 mod scroll_text;
@@ -35,6 +36,7 @@ pub use data_input::{
 };
 pub use label::ConsoleUiLabel;
 pub use list::{ConsoleUiList, ConsoleUiListEntryStyle, ConsoleUiListStyles};
+pub use mnemonic_input::get_mnemonic_input;
 pub use numeric_input::{ConsoleUiNumericInput, ConsoleUiNumericInputStyles};
 pub use program_selector::ConsoleUiProgramSelector;
 pub use scroll_text::{ConsoleUiScrollText, ConsoleUiScrollTextStyles};

--- a/bst/src/ui/console/numeric_input.rs
+++ b/bst/src/ui/console/numeric_input.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use macros::s16;
 
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConsoleUiNumericInputStyles {
     numeric_base_selection_title_styles: ConsoleUiTitleStyles,
     numeric_base_selection_list_styles: ConsoleUiListStyles,
@@ -81,7 +81,7 @@ impl ConsoleUiNumericInputStyles {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct ConsoleUiNumericInput<'a, TSystemServices: SystemServices> {
     system_services: &'a TSystemServices,
     styles: ConsoleUiNumericInputStyles,

--- a/bst/src/ui/console/scroll_text.rs
+++ b/bst/src/ui/console/scroll_text.rs
@@ -27,7 +27,7 @@ use crate::{
 use alloc::{vec, vec::Vec};
 use macros::{c16, s16};
 
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConsoleUiScrollTextStyles {
     scroll_indicator_colours: ConsoleColours,
     wrap_indicator_colours: ConsoleColours,
@@ -103,7 +103,7 @@ impl ConsoleUiScrollTextStyles {
     }
 }
 
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConsoleUiScrollText {
     character_predicate: Option<fn(character: u16) -> bool>,
     styles: ConsoleUiScrollTextStyles,

--- a/bst/src/ui/console/text_box.rs
+++ b/bst/src/ui/console/text_box.rs
@@ -35,7 +35,7 @@ pub enum PasteResult {
     RewritePadding,
 }
 
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConsoleUiTextBoxStyles {
     scroll_text_styles: ConsoleUiScrollTextStyles,
     completion_message_colours: ConsoleColours,
@@ -89,7 +89,7 @@ impl ConsoleUiTextBoxStyles {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct ConsoleUiTextBox<'a, TSystemServices: SystemServices> {
     system_services: &'a TSystemServices,
     styles: ConsoleUiTextBoxStyles,

--- a/bst/src/ui/console/title.rs
+++ b/bst/src/ui/console/title.rs
@@ -106,6 +106,7 @@ impl ConsoleUiTitleStyles {
     }
 }
 
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConsoleUiTitle<'a> {
     styles: ConsoleUiTitleStyles,
     content: String16<'a>,

--- a/bst/src/ui/list.rs
+++ b/bst/src/ui/list.rs
@@ -17,7 +17,6 @@
 use crate::String16;
 use core::ops::Deref;
 
-#[allow(dead_code)]
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum UiListType {
     Select,

--- a/bst/src/ui/list.rs
+++ b/bst/src/ui/list.rs
@@ -18,7 +18,7 @@ use crate::String16;
 use core::ops::Deref;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum UiListType {
     Select,
     Ordered(usize),


### PR DESCRIPTION
# BIP 32 Seed Derivation

- Implement a generic seed derivation program based on PBKDF2-ing a mnemonic string with an extension phrase as a salt.
- Use this generic program for BIP 39 word-list based derivation of both BIP 39 and Electrum mnemonics.
- Implement simple extension phrases which do not require NFKD normalization.

## Pre-Merge Tasks
- [x] Update #2 
- [x] Self-Review
- [x] Address self-review comments
- [x] Self-Review 2
- [x] Address self-review 2 comments

## Potential Follow-Ups

- Arbitrary string mnemonics using the Electrum Seed Version system. #4 
- Full normalization. #5

## Post-Merge Tasks
- [ ] New Tag
- [ ] Update #2