### PR TITLE
[FEATURE] Public Key Derivation for secp256k1

### DIFF
--- a/bst/src/bitcoin/hd_wallets/mod.rs
+++ b/bst/src/bitcoin/hd_wallets/mod.rs
@@ -24,24 +24,11 @@ use alloc::vec::Vec;
 // Serialized keys are prefixed with version bytes.
 pub const MAIN_NET_PRIVATE_KEY_VERSION: u32 = 0x0488ADE4;
 pub const TEST_NET_PRIVATE_KEY_VERSION: u32 = 0x04358394;
-
-#[allow(dead_code)]
 pub const MAIN_NET_PUBLIC_KEY_VERSION: u32 = 0x0488B21E;
-
-#[allow(dead_code)]
 pub const TEST_NET_PUBLIC_KEY_VERSION: u32 = 0x043587CF;
 
 // The key used for HMAC-based BIP 32 master key derivation.
 const KEY_DERIVATION_KEY_BYTES: &[u8] = "Bitcoin seed".as_bytes();
-
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-pub enum KeyType {
-    #[allow(dead_code)]
-    Private,
-
-    #[allow(dead_code)]
-    Public,
-}
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Bip32KeyVersion {
@@ -134,7 +121,7 @@ pub fn try_derive_master_key(
     chain_code.copy_from_slice(&hmac_result[32..]);
 
     // The serialized form of a private key is left-padded with a single 0 byte.
-    let key_material = serialized_private_key_bytes(&hmac_result[..32]);
+    let key_material = secp256k1::serialized_private_key_bytes(&hmac_result[..32]);
 
     // Fill HMAC copy of key & chain code.
     hmac_result.fill(0);
@@ -150,11 +137,4 @@ pub fn try_derive_master_key(
         chain_code,
         depth: 0,
     })
-}
-
-fn serialized_private_key_bytes(key: &[u8]) -> [u8; 33] {
-    // Private keys are prefixed with a single 0 byte in the format.
-    let mut bytes = [0u8; 33];
-    bytes[1..].copy_from_slice(key);
-    bytes
 }

--- a/bst/src/console_out.rs
+++ b/bst/src/console_out.rs
@@ -52,7 +52,6 @@ impl ConsoleCursorState {
         self.position
     }
 
-    #[allow(dead_code)]
     pub const fn visible(&self) -> bool {
         self.visible
     }
@@ -102,7 +101,6 @@ impl ConsoleColours {
         }
     }
 
-    #[allow(dead_code)]
     pub const fn background_only(colour: ConsoleColour) -> Self {
         Self {
             foreground: ConsoleColour::Inherit,

--- a/bst/src/cryptography/asymmetric/ecc.rs
+++ b/bst/src/cryptography/asymmetric/ecc.rs
@@ -1,0 +1,15 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/bst/src/cryptography/asymmetric/ecc.rs
+++ b/bst/src/cryptography/asymmetric/ecc.rs
@@ -13,3 +13,133 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::integers::BigSigned;
+
+struct Point {
+    x: BigSigned,
+    y: BigSigned,
+}
+
+impl Point {
+    pub fn is_infinity(&self) -> bool {
+        // The identity point of the curve; (X, Y) + -(X, Y) = Infinity.
+        // Where I is Infinity, and P is another point:
+        // I + I = I
+        // I + P = P
+        self.x.is_zero() && self.y.is_zero()
+    }
+
+    pub fn negate(&mut self) {
+        // A negated point means that P + -P = Infinity
+        // (x, y) + -(x, y) = I
+        // (x, y) + (x, -y) = I
+        // (x, -y) = -(x, y)
+        self.y.negate()
+    }
+
+    pub fn double(&mut self, context: &mut PointMultiplicationContext) {
+        if self.is_infinity() {
+            // I + I = I
+            return;
+        }
+
+        context.prepare_doubling(&self);
+
+        // Point addition and doubling both consist of two steps: calculating a lambda value λ, then applying it.
+        // The application of λ is the same for doubling and addition, but the calculation of λ is different.
+        // Where p is the point to double, for doubling, the calculation is:
+        // λ = (3 * (Xp * Xp) + a) / (2 * Yp)
+        // TODO
+
+        self.update_With_lambda(context);
+    }
+
+    pub fn add(&mut self, addend: &Point, context: &mut PointMultiplicationContext) {
+        if self.is_infinity() {
+            // I + P = P
+            self.x.set_equal_to(&addend.x);
+            self.y.set_equal_to(&addend.y);
+            return;
+        }
+
+        if addend.is_infinity() {
+            // P + I = P
+            return;
+        }
+
+        if addend.x == self.x {
+            if addend.y != self.y {
+                // The points are mutual inverses; the result is infinity.
+                self.x.zero();
+                self.y.zero();
+                return;
+            }
+
+            // Where added points are coincident (the same), we need to use the doubling algorithm instead.
+            self.double(context);
+            return;
+        }
+
+        context.prepare_addition(&self, addend);
+
+        // Point addition and doubling both consist of two steps: calculating a lambda value λ, then applying it.
+        // The application of λ is the same for doubling and addition, but the calculation of λ is different.
+        // Where p = augend, q = addend, for addition, the calculation is:
+        // λ = (Yq - Yp) / (Xq - Xp)
+        // TODO
+
+        self.update_With_lambda(context);
+    }
+
+    fn update_With_lambda(&mut self, context: &mut PointMultiplicationContext) {
+        // Where p = augend, q = addend, r is the result, and λ is the temporary field from point addition or doubling:
+        // Xr = λ^2 - Xp - Xq
+        // Yr = (λ * (Xp - Xr)) - Yp
+
+        // Xr = λ
+        self.x.set_equal_to(&context.lambda);
+
+        // Xr = λ * λ = λ^2
+        self.x.multiply_big_signed(&context.lambda);
+
+        // Xr = λ^2 - Xp
+        self.x.subtract_big_signed(&context.x_augend);
+
+        // Xr = λ^2 - Xp - Xq
+        self.x.subtract_big_signed(&context.x_addend);
+
+        // Yr = Xp
+        self.y.set_equal_to(&context.x_augend);
+
+        // Yr = Xp - Xr
+        self.y.subtract_big_signed(&self.x);
+
+        // Yr = λ * (Xp - Xr)
+        self.y.multiply_big_signed(&context.lambda);
+
+        // Yr = (λ * (Xp - Xr)) - Yp
+        self.y.subtract_big_signed(&context.y_augend);
+    }
+}
+
+struct PointMultiplicationContext {
+    x_augend: BigSigned,
+    y_augend: BigSigned,
+    x_addend: BigSigned,
+    lambda: BigSigned,
+}
+
+impl PointMultiplicationContext {
+    fn prepare_doubling(&mut self, point: &Point) {
+        self.x_addend.set_equal_to(&point.x);
+        self.x_augend.set_equal_to(&point.x);
+        self.y_augend.set_equal_to(&point.y);
+    }
+
+    fn prepare_addition(&mut self, augend: &Point, addend: &Point) {
+        self.x_addend.set_equal_to(&addend.x);
+        self.x_augend.set_equal_to(&augend.x);
+        self.y_augend.set_equal_to(&augend.y);
+    }
+}

--- a/bst/src/cryptography/asymmetric/mod.rs
+++ b/bst/src/cryptography/asymmetric/mod.rs
@@ -16,3 +16,9 @@
 
 pub mod ecc;
 pub mod secp256k1;
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AsymmetricKeyType {
+    Private,
+    Public,
+}

--- a/bst/src/cryptography/asymmetric/mod.rs
+++ b/bst/src/cryptography/asymmetric/mod.rs
@@ -1,0 +1,18 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub mod ecc;
+pub mod secp256k1;

--- a/bst/src/cryptography/asymmetric/secp256k1.rs
+++ b/bst/src/cryptography/asymmetric/secp256k1.rs
@@ -1,0 +1,31 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{global_runtime_immutable::GlobalRuntimeImmutable, integers::BigUnsigned};
+
+// The maximum value for a secp256k1 private key.
+static mut N: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
+    GlobalRuntimeImmutable::from(|| {
+        BigUnsigned::from_be_bytes(&[
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
+            0xD0, 0x36, 0x41, 0x41,
+        ])
+    });
+
+pub fn n() -> &'static BigUnsigned {
+    unsafe { N.value() }
+}

--- a/bst/src/cryptography/asymmetric/secp256k1.rs
+++ b/bst/src/cryptography/asymmetric/secp256k1.rs
@@ -16,7 +16,21 @@
 
 use crate::{global_runtime_immutable::GlobalRuntimeImmutable, integers::BigUnsigned};
 
+// secp256k1 private keys are a 256 bit integer, while their public keys consist of two 256 bit coordinates.
+// Due to the properties of the secp256k1 curve, however, public keys can be represented with a single coordinate, and a flag indicating
+// whether the missing coordinate is even or odd. This means we can represent any secp256k1 key with 33 bytes; the first byte is a 'flag' indicating
+// how the following 32 bytes should be interpreted.
+// In the case of a private key, the flag is 0.
+const PRIVATE_KEY_TAG: u8 = 0x00;
+
+// Public keys where the missing coordinate is even have a flag of 2.
+const PUBLIC_KEY_TAG_EVEN: u8 = 0x02;
+
+// Public keys where the missing coordinate is odd have a flag of 3.
+const PUBLIC_KEY_TAG_ODD: u8 = 0x03;
+
 // The maximum value for a secp256k1 private key.
+// n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
 static mut N: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
     GlobalRuntimeImmutable::from(|| {
         BigUnsigned::from_be_bytes(&[
@@ -26,6 +40,67 @@ static mut N: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
         ])
     });
 
+// The additive coefficient for point doubling.
+static mut A: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
+    GlobalRuntimeImmutable::from(|| BigUnsigned::from_be_bytes(&[0x01]));
+
+// The order of the finite field; the modulus to use when performing scalar multiplication.
+// p = 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
+// = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE FFFFFC2F
+static mut P: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
+    GlobalRuntimeImmutable::from(|| {
+        BigUnsigned::from_be_bytes(&[
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+            0xFF, 0xFF, 0xFC, 0x2F,
+        ])
+    });
+
+// The starting X coordinate for scalar multiplication.
+// Gx = 79BE667E F9DCBBAC 55A06295 CE870B07 029BFCDB 2DCE28D9 59F2815B 16F81798
+static mut GX: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
+    GlobalRuntimeImmutable::from(|| {
+        BigUnsigned::from_be_bytes(&[
+            0x79, 0xBE, 0x66, 0x7E, 0xF9, 0xDC, 0xBB, 0xAC, 0x55, 0xA0, 0x62, 0x95, 0xCE, 0x87,
+            0x0B, 0x07, 0x02, 0x9B, 0xFC, 0xDB, 0x2D, 0xCE, 0x28, 0xD9, 0x59, 0xF2, 0x81, 0x5B,
+            0x16, 0xF8, 0x17, 0x98,
+        ])
+    });
+
+// The starting Y coordinate for scalar multiplication.
+// Gy = 483ADA77 26A3C465 5DA4FBFC 0E1108A8 FD17B448 A6855419 9C47D08F FB10D4B8
+static mut GY: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
+    GlobalRuntimeImmutable::from(|| {
+        BigUnsigned::from_be_bytes(&[
+            0x48, 0x3A, 0xDA, 0x77, 0x26, 0xA3, 0xC4, 0x65, 0x5D, 0xA4, 0xFB, 0xFC, 0x0E, 0x11,
+            0x08, 0xA8, 0xFD, 0x17, 0xB4, 0x48, 0xA6, 0x85, 0x54, 0x19, 0x9C, 0x47, 0xD0, 0x8F,
+            0xFB, 0x10, 0xD4, 0xB8,
+        ])
+    });
+
 pub fn n() -> &'static BigUnsigned {
     unsafe { N.value() }
+}
+
+fn a() -> &'static BigUnsigned {
+    unsafe { A.value() }
+}
+
+fn p() -> &'static BigUnsigned {
+    unsafe { P.value() }
+}
+
+fn gx() -> &'static BigUnsigned {
+    unsafe { GX.value() }
+}
+
+fn gy() -> &'static BigUnsigned {
+    unsafe { GY.value() }
+}
+
+pub fn serialized_private_key_bytes(key: &[u8]) -> [u8; 33] {
+    let mut bytes = [0u8; 33];
+    bytes[0] = PRIVATE_KEY_TAG;
+    bytes[1..].copy_from_slice(key);
+    bytes
 }

--- a/bst/src/cryptography/mod.rs
+++ b/bst/src/cryptography/mod.rs
@@ -1,0 +1,17 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub mod asymmetric;

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -102,7 +102,7 @@ impl BigUnsigned {
         Self { digits: bytes }
     }
 
-    fn from_vec(digits: Vec<u8>) -> Self {
+    pub fn from_vec(digits: Vec<u8>) -> Self {
         let mut value = Self { digits };
         value.trim_leading_zeroes();
         value
@@ -110,7 +110,7 @@ impl BigUnsigned {
 }
 
 impl BigSigned {
-    fn from_unsigned(is_negative: bool, big_unsigned: BigUnsigned) -> Self {
+    pub fn from_unsigned(is_negative: bool, big_unsigned: BigUnsigned) -> Self {
         Self {
             is_negative: is_negative && big_unsigned.is_non_zero(),
             big_unsigned,
@@ -121,7 +121,7 @@ impl BigSigned {
         Self::from_unsigned(is_negative, BigUnsigned::from_be_bytes(be_bytes))
     }
 
-    fn from_vec(is_negative: bool, digits: Vec<u8>) -> Self {
+    pub fn from_vec(is_negative: bool, digits: Vec<u8>) -> Self {
         Self::from_unsigned(is_negative, BigUnsigned::from_vec(digits))
     }
 

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -259,6 +259,11 @@ impl BigUnsigned {
 }
 
 impl BigSigned {
+    pub fn set_equal_to_unsigned(&mut self, unsigned_value: &BigUnsigned, is_negative: bool) {
+        self.big_unsigned.set_equal_to(unsigned_value);
+        self.is_negative = is_negative;
+    }
+
     pub fn set_equal_to(&mut self, value: &Self) {
         self.big_unsigned.set_equal_to(&value.big_unsigned);
         self.is_negative = value.is_negative;

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
 use alloc::{boxed::Box, vec::Vec};
 use core::{cmp::Ordering, mem::size_of};
 

--- a/bst/src/keyboard_in.rs
+++ b/bst/src/keyboard_in.rs
@@ -101,7 +101,6 @@ pub enum Key {
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ToggleKeys(u8);
 
-#[allow(dead_code)]
 impl ToggleKeys {
     pub const NONE: Self = Self(0);
     pub const NUM_LOCK: Self = Self(1);
@@ -174,7 +173,6 @@ impl BitXorAssign for ToggleKeys {
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ModifierKeys(u16);
 
-#[allow(dead_code)]
 impl ModifierKeys {
     pub const NONE: Self = Self(0);
     pub const RIGHT_SHIFT: Self = Self(1);
@@ -320,7 +318,6 @@ impl KeyPress {
         self.modifier_keys
     }
 
-    #[allow(dead_code)]
     pub const fn toggle_keys(self) -> ToggleKeys {
         self.toggle_keys
     }

--- a/bst/src/main.rs
+++ b/bst/src/main.rs
@@ -24,6 +24,7 @@ mod characters;
 mod clipboard;
 mod console_out;
 mod constants;
+mod cryptography;
 mod global_runtime_immutable;
 mod hashing;
 mod integers;

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -35,7 +35,6 @@ pub enum PowerAction {
     Reset,
 }
 
-#[allow(dead_code)]
 pub fn clock_cycle_count() -> u64 {
     #[cfg(target_arch = "aarch64")]
     unsafe {

--- a/bst/src/ui/alignment.rs
+++ b/bst/src/ui/alignment.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum UiElementAlignment {
     Left,

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -236,7 +236,6 @@ pub fn prompt_for_u32<
     )
 }
 
-#[allow(dead_code)]
 pub fn prompt_for_u64<
     'a,
     TSystemServices: SystemServices,
@@ -259,7 +258,6 @@ pub fn prompt_for_u64<
     )
 }
 
-#[allow(dead_code)]
 pub fn prompt_for_u128<
     'a,
     TSystemServices: SystemServices,


### PR DESCRIPTION
# Public Key Derivation for secp256k1 (#8)

- Implements secp256k1 public key derivation through a generic ECC Public Key Derivation program.

## Pre-Merge Tasks
- [ ] Implementation
- [ ] Self-Review

## Post-Merge Tasks
- [ ] New Tag
- [ ] Update #2
