### PR TITLE
Program Error Cleanup

### DIFF
--- a/bst/src/bitcoin/mnemonics/electrum/mod.rs
+++ b/bst/src/bitcoin/mnemonics/electrum/mod.rs
@@ -183,7 +183,7 @@ pub fn try_generate_mnemonic(
         if i == start_bit_offset {
             // We ran out of increment space; all the bits are 1. The user did something stupid.
             return Err(s16!(
-                "Mnemonic generation failed due to integer overflow; your entropy was bad."
+                "Mnemonic generation failed due to integer overflow; your entropy was probably bad."
             ));
         }
 

--- a/bst/src/main.rs
+++ b/bst/src/main.rs
@@ -77,14 +77,14 @@ fn initialize_console<T: SystemServices>(
 }
 
 fn run_console_ui<T: SystemServices>(system_services: T) {
-    let console = initialize_console(&system_services, constants::DEFAULT_COLOURS);
+    initialize_console(&system_services, constants::DEFAULT_COLOURS);
     let program_selector = ConsoleUiProgramSelector::from(
         constants::BIG_TITLE,
         constants::SELECT_LIST,
         system_services.clone(),
     );
 
-    let exit_handler = ConsoleDumpingProgramExitResultHandler::from(console.clone());
+    let exit_handler = ConsoleDumpingProgramExitResultHandler::from(system_services.clone());
     loop {
         get_programs_list(&system_services, &program_selector, &exit_handler).run();
         if ConsoleUiConfirmationPrompt::from(&system_services)

--- a/bst/src/programs/console/cryptography/asymmetric/ec_public_key_derivation.rs
+++ b/bst/src/programs/console/cryptography/asymmetric/ec_public_key_derivation.rs
@@ -118,13 +118,7 @@ impl<TSystemServices: SystemServices> Program
                 .multiply_point(curve.g_x, curve.g_y, &private_key)
             {
                 Some(point) => point,
-                None => {
-                    return ProgramExitResult::String16Error(
-                        s16!("Failed to derive a public key.")
-                            .content_slice()
-                            .into(),
-                    );
-                }
+                None => return s16!("Failed to derive a public key.").to_program_error(),
             };
 
         // We're done with the private key; zero it.
@@ -133,13 +127,7 @@ impl<TSystemServices: SystemServices> Program
         // Serialize the public key for output.
         let serialized_point = match (curve.point_serializer)(point) {
             Some(serialized_point) => serialized_point,
-            None => {
-                return ProgramExitResult::String16Error(
-                    s16!("Failed to serialize the public key.")
-                        .content_slice()
-                        .into(),
-                );
-            }
+            None => return s16!("Failed to serialize the public key.").to_program_error(),
         };
 
         write_bytes(&self.system_services, s16!("Public Key"), &serialized_point);

--- a/bst/src/programs/console/cryptography/asymmetric/ec_public_key_derivation.rs
+++ b/bst/src/programs/console/cryptography/asymmetric/ec_public_key_derivation.rs
@@ -24,10 +24,9 @@ use crate::{
     system_services::SystemServices,
     ui::{
         console::{
-            prompt_for_clipboard_write, prompt_for_data_input, ConsoleUiContinuePrompt,
-            ConsoleUiTitle, ConsoleWriteable,
+            prompt_for_clipboard_write, prompt_for_data_input, ConsoleUiTitle, ConsoleWriteable,
         },
-        ContinuePrompt, DataInput, DataInputType,
+        DataInput, DataInputType,
     },
     String16,
 };
@@ -120,15 +119,8 @@ impl<TSystemServices: SystemServices> Program
             {
                 Some(point) => point,
                 None => {
-                    console.in_colours(constants::ERROR_COLOURS, |c| {
-                        c.line_start().new_line().output_utf16(s16!(
-                            "Failed to derive a public key; this shouldn't have happened."
-                        ))
-                    });
-
-                    ConsoleUiContinuePrompt::from(&self.system_services).prompt_for_continue();
                     return ProgramExitResult::String16Error(
-                        s16!("Public key derivation failure.")
+                        s16!("Failed to derive a public key.")
                             .content_slice()
                             .into(),
                     );
@@ -142,15 +134,8 @@ impl<TSystemServices: SystemServices> Program
         let serialized_point = match (curve.point_serializer)(point) {
             Some(serialized_point) => serialized_point,
             None => {
-                console.in_colours(constants::ERROR_COLOURS, |c| {
-                    c.line_start().new_line().output_utf16(s16!(
-                        "Failed to serialize the public key; this shouldn't have happened."
-                    ))
-                });
-
-                ConsoleUiContinuePrompt::from(&self.system_services).prompt_for_continue();
                 return ProgramExitResult::String16Error(
-                    s16!("Public key serialization failure.")
+                    s16!("Failed to serialize the public key.")
                         .content_slice()
                         .into(),
                 );

--- a/bst/src/programs/console/cryptography/bip_32_master_key_derivation.rs
+++ b/bst/src/programs/console/cryptography/bip_32_master_key_derivation.rs
@@ -134,10 +134,8 @@ impl<TSystemServices: SystemServices> Program
             None => {
                 // We generated a key outside the bounds of valid secp256k1 keys. This is extremely unlikely,
                 // and knowing the input would be a useful test vector because such a test vector is not yet known.
-                ProgramExitResult::String16Error(
-                    s16!("BIP 32 Key Derivation escaped the range of valid secp256k1 keys.")
-                        .to_program_error(),
-                )
+                s16!("BIP 32 Key Derivation escaped the range of valid secp256k1 keys.")
+                    .to_program_error()
             }
         }
     }

--- a/bst/src/programs/console/cryptography/bip_32_master_key_derivation.rs
+++ b/bst/src/programs/console/cryptography/bip_32_master_key_derivation.rs
@@ -24,10 +24,9 @@ use crate::{
     ui::{
         console::{
             prompt_for_clipboard_write, prompt_for_data_input, ConsoleUiConfirmationPrompt,
-            ConsoleUiContinuePrompt, ConsoleUiLabel, ConsoleUiList, ConsoleUiTitle,
-            ConsoleWriteable,
+            ConsoleUiLabel, ConsoleUiList, ConsoleUiTitle, ConsoleWriteable,
         },
-        ConfirmationPrompt, ContinuePrompt, DataInput, DataInputType,
+        ConfirmationPrompt, DataInput, DataInputType,
     },
     String16,
 };
@@ -135,17 +134,9 @@ impl<TSystemServices: SystemServices> Program
             None => {
                 // We generated a key outside the bounds of valid secp256k1 keys. This is extremely unlikely,
                 // and knowing the input would be a useful test vector because such a test vector is not yet known.
-                console.in_colours(constants::ERROR_COLOURS, |c| {
-                    c.line_start().new_line().output_utf16(s16!("A key could not be derived from the input bytes. This shouldn't have happened; please report a bug."))
-                });
-
-                ConsoleUiContinuePrompt::from(&self.system_services).prompt_for_continue();
                 ProgramExitResult::String16Error(
-                    unsafe {
-                        s16!("BIP 32 key derivation escaped the range of valid secp256k1 keys.")
-                            .get_underlying_slice()
-                    }
-                    .into(),
+                    s16!("BIP 32 Key Derivation escaped the range of valid secp256k1 keys.")
+                        .to_program_error(),
                 )
             }
         }

--- a/bst/src/programs/console/entropy/mnemonics/mnemonic_entropy_encoder.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mnemonic_entropy_encoder.rs
@@ -160,14 +160,6 @@ impl<TMnemonicEncoder: MnemonicEncoder, TSystemServices: SystemServices> Program
                     match message {
                         Some(message) => {
                             // We can't create a mnemonic with the provided bytes for some reason; print the error.
-                            console
-                                .line_start()
-                                .new_line()
-                                .in_colours(constants::ERROR_COLOURS, |c| {
-                                    c.output_utf16_line(message)
-                                });
-                            ConsoleUiContinuePrompt::from(&self.system_services)
-                                .prompt_for_continue();
                             return ProgramExitResult::String16Error(
                                 message.content_slice().into(),
                             );

--- a/bst/src/programs/console/entropy/mnemonics/mnemonic_entropy_encoder.rs
+++ b/bst/src/programs/console/entropy/mnemonics/mnemonic_entropy_encoder.rs
@@ -160,9 +160,7 @@ impl<TMnemonicEncoder: MnemonicEncoder, TSystemServices: SystemServices> Program
                     match message {
                         Some(message) => {
                             // We can't create a mnemonic with the provided bytes for some reason; print the error.
-                            return ProgramExitResult::String16Error(
-                                message.content_slice().into(),
-                            );
+                            return message.to_program_error();
                         }
                         None => {
                             // The user cancelled mnemonic generation.

--- a/bst/src/string16.rs
+++ b/bst/src/string16.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::programs::ProgramExitResult;
 #[cfg(test)]
 use alloc::string::String;
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 #[cfg(test)]
 use core::fmt::{self, Debug, Formatter};
 use core::{char::decode_utf16, cmp::Ordering, slice::Iter};
@@ -117,7 +118,7 @@ impl<'a> String16<'a> {
         self.0.len() == 0 || self.0[0] == 0
     }
 
-    pub fn to_program_error(&self) -> Box<[u16]> {
-        self.0.into()
+    pub fn to_program_error(&self) -> ProgramExitResult {
+        ProgramExitResult::String16Error(self.0.into())
     }
 }

--- a/bst/src/string16.rs
+++ b/bst/src/string16.rs
@@ -16,7 +16,7 @@
 
 #[cfg(test)]
 use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 #[cfg(test)]
 use core::fmt::{self, Debug, Formatter};
 use core::{char::decode_utf16, cmp::Ordering, slice::Iter};
@@ -115,5 +115,9 @@ impl<'a> String16<'a> {
 
     pub fn is_empty(&self) -> bool {
         self.0.len() == 0 || self.0[0] == 0
+    }
+
+    pub fn to_program_error(&self) -> Box<[u16]> {
+        self.0.into()
     }
 }

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -127,7 +127,7 @@ pub trait SystemServices: Clone + 'static {
 static mut PANIC_COUNTER: usize = 0;
 
 const PANIC_HEADER: String16 =
-    s16!("[PANIC]: An unrecoverable error has occurred. Exiting BST in 60 seconds...\r\n\r\nPlease consider reporting this in an issue at:\r\nhttps://github.com/PoodleLabs/PoodleLabs.BST\r\n\r\nInclude details of what you were doing, and the following message:");
+    s16!("[PANIC]: An unrecoverable error has occurred. Exiting BST in 60 seconds...\r\n\r\nPlease consider reporting this in an issue at:\r\nhttps://github.com/PoodleLabs/PoodleLabs.BootableSecurityTools\r\n\r\nInclude details of what you were doing, and the following message:");
 
 const PANIC_RECURSE: String16 =
     s16!("Three panics occurred recursively; this is likely due to you running out of memory.");


### PR DESCRIPTION
Reduces code duplication in program error handling; previously we were writing an error message and prompting for continuation manually in each program, then writing the output to the console invisibly, rendering the program exit result handler utterly useless.

Now we just return an error message with an error program exit result, and the error result handler displays it and prompts for continuation.