### PR TITLE
[BUG] Byte/Numeric Input Unnecessary Redraw Fix

### DIFF
--- a/bst/src/ui/console/numeric_input.rs
+++ b/bst/src/ui/console/numeric_input.rs
@@ -162,7 +162,11 @@ impl<'a, TSystemServices: SystemServices> ConsoleUiNumericInput<'a, TSystemServi
                                 }
                             }
 
-                            PasteResult::Rewrite
+                            if is_in_base {
+                                PasteResult::ContinueAsNormal
+                            } else {
+                                PasteResult::Rewrite
+                            }
                         }
                         // We can't write text to a numeric input, so any other paste types just get ignored.
                         _ => PasteResult::ContinueAsNormal,


### PR DESCRIPTION
# Byte/Numeric Input Unnecessary Redraw Fix (#28)

Fixes unnecessary redraw when pasting text whose characters are all valid within a byte/numeric input's selected base.

![image](https://github.com/PoodleLabs/PoodleLabs.BootableSecurityTools/assets/23095702/cad8b94d-7fd7-486d-aa94-df6815e5dfc8)

![image](https://github.com/PoodleLabs/PoodleLabs.BootableSecurityTools/assets/23095702/f4d82cb5-a3b6-4716-af0c-ef76627282a7)
