### PR TITLE
[FEATURE] Long-Based Big Integer Types

### DIFF
--- a/bst/src/bitcoin/hd_wallets/derivation_paths.rs
+++ b/bst/src/bitcoin/hd_wallets/derivation_paths.rs
@@ -134,9 +134,9 @@ impl Bip32DerivationPathPoint {
 
                     // Copy the resulting key into a new key material buffer.
                     let mut key_material = [0u8; 33];
-                    private_key_buffer.copy_be_bytes_to(
+                    assert!(private_key_buffer.try_copy_be_bytes_to(
                         &mut key_material[33 - private_key_buffer.byte_count()..],
-                    );
+                    ));
 
                     // Zero our private key buffer; we're done with it.
                     private_key_buffer.zero();

--- a/bst/src/bitcoin/hd_wallets/derivation_paths.rs
+++ b/bst/src/bitcoin/hd_wallets/derivation_paths.rs
@@ -274,8 +274,8 @@ impl Bip32CkdContext {
     pub fn new() -> Self {
         Self {
             multiplication_context: secp256k1::point_multiplication_context(),
-            point_buffer: EllipticCurvePoint::infinity(32),
-            private_key_buffer: BigUnsigned::with_capacity(32),
+            point_buffer: EllipticCurvePoint::infinity(4),
+            private_key_buffer: BigUnsigned::with_capacity(4),
             hash160: Hash160::new(),
             sha512: Sha512::new(),
         }

--- a/bst/src/bitcoin/hd_wallets/derivation_paths.rs
+++ b/bst/src/bitcoin/hd_wallets/derivation_paths.rs
@@ -273,9 +273,9 @@ pub struct Bip32CkdContext {
 impl Bip32CkdContext {
     pub fn new() -> Self {
         Self {
+            point_buffer: EllipticCurvePoint::infinity(32),
             multiplication_context: secp256k1::point_multiplication_context(),
-            point_buffer: EllipticCurvePoint::infinity(4),
-            private_key_buffer: BigUnsigned::with_capacity(4),
+            private_key_buffer: BigUnsigned::with_byte_capacity(32),
             hash160: Hash160::new(),
             sha512: Sha512::new(),
         }

--- a/bst/src/bitcoin/hd_wallets/derivation_paths.rs
+++ b/bst/src/bitcoin/hd_wallets/derivation_paths.rs
@@ -21,7 +21,7 @@ use crate::{
         self, secp256k1, EllipticCurvePoint, EllipticCurvePointMultiplicationContext,
     },
     hashing::{Hasher, Sha512},
-    integers::BigUnsigned,
+    integers::{BigUnsigned, Digit},
     String16,
 };
 use core::cmp::Ordering;
@@ -87,7 +87,7 @@ impl Bip32DerivationPathPoint {
         let (parent_public_key, key_material): ([u8; 33], [u8; 33]) = match key_version.key_type() {
             Bip32KeyType::Private => {
                 // Write the private key to the private key buffer.
-                private_key_buffer.copy_digits_from(parent_key.key_material());
+                private_key_buffer.copy_be_bytes_from(parent_key.key_material());
 
                 // Derive the EC point for the public key.
                 let point = match multiplication_context.multiply_point(
@@ -118,21 +118,25 @@ impl Bip32DerivationPathPoint {
                     data[33..].copy_from_slice(&index.to_be_bytes());
                     hmac.write_hmac_to(&data, &mut hmac_buffer);
 
-                    let km = &hmac_buffer[..32];
-                    match Self::validate_key_material(km, &mut index) {
+                    let (km, _) = point_buffer.borrow_coordinates_mut();
+                    let km = km.borrow_unsigned_mut();
+                    km.copy_be_bytes_from(&hmac_buffer[..32]);
+
+                    match Self::validate_key_material(km.borrow_digits(), &mut index) {
                         IlValidationResult::Ok => {}
                         IlValidationResult::NextIteration => continue,
                         IlValidationResult::ReturnError(e) => return Err(e),
                     }
 
                     // Add parent private key and child private key material; ppk + cpk (mod n).
-                    private_key_buffer.add_be_bytes(&km);
+                    private_key_buffer.add_big_unsigned(&km);
                     private_key_buffer.modulo_big_unsigned(secp256k1::n());
 
                     // Copy the resulting key into a new key material buffer.
                     let mut key_material = [0u8; 33];
-                    key_material[33 - private_key_buffer.digit_count()..]
-                        .copy_from_slice(private_key_buffer.borrow_digits());
+                    private_key_buffer.copy_be_bytes_to(
+                        &mut key_material[33 - private_key_buffer.byte_count()..],
+                    );
 
                     // Zero our private key buffer; we're done with it.
                     private_key_buffer.zero();
@@ -163,7 +167,7 @@ impl Bip32DerivationPathPoint {
 
                 let (x, y) = point_buffer.borrow_coordinates_mut();
                 // Write the X coordinate of the parent public key into the working point.
-                x.copy_digits_from(&parent_public_key[1..], false);
+                x.copy_be_bytes_from(&parent_public_key[1..], false);
 
                 // Ensure the working point's Y value is positive.
                 y.set_sign(false);
@@ -181,7 +185,7 @@ impl Bip32DerivationPathPoint {
                     hmac.write_hmac_to(&data, &mut hmac_buffer);
 
                     // Write the child key material to the private key buffer.
-                    private_key_buffer.copy_digits_from(&hmac_buffer[..32]);
+                    private_key_buffer.copy_be_bytes_from(&hmac_buffer[..32]);
                     match Self::validate_key_material(
                         private_key_buffer.borrow_digits(),
                         &mut index,
@@ -238,7 +242,7 @@ impl Bip32DerivationPathPoint {
         ))
     }
 
-    fn validate_key_material(key_material: &[u8], index: &mut u32) -> IlValidationResult {
+    fn validate_key_material(key_material: &[Digit], index: &mut u32) -> IlValidationResult {
         if key_material.iter().all(|c| *c == 0)
             || secp256k1::n().partial_cmp(key_material).unwrap() != Ordering::Greater
         {

--- a/bst/src/bitcoin/mod.rs
+++ b/bst/src/bitcoin/mod.rs
@@ -67,9 +67,7 @@ pub fn base_58_encode_with_checksum(bytes: &[u8]) -> Vec<u16> {
     }
 
     // Extract the underlying big unsigned integer.
-    let mut integer = numeric_collector
-        .extract_big_unsigned()
-        .take_data_ownership();
+    let mut integer = numeric_collector.extract_big_unsigned();
 
     // Build a base-58 string from the big integer.
     let base_58_string =

--- a/bst/src/bits.rs
+++ b/bst/src/bits.rs
@@ -34,57 +34,57 @@ pub trait BitTarget: Sized + Eq + Copy {
     fn zero() -> Self;
 }
 
-impl BitTarget for u8 {
-    fn right_shift(self, by: usize) -> Self {
-        self >> by
-    }
+macro_rules! bit_target_integer {
+    ($($integer:ident $shift_start_offset:ident,)*) => {
+        $(
+            #[allow(dead_code)]
+            impl BitTarget for $integer {
+                fn right_shift(self, by: usize) -> Self {
+                    self >> by
+                }
 
-    fn and(self, value: Self) -> Self {
-        self & value
-    }
+                fn and(self, value: Self) -> Self {
+                    self & value
+                }
 
-    fn or(self, value: Self) -> Self {
-        self | value
-    }
+                fn or(self, value: Self) -> Self {
+                    self | value
+                }
 
-    fn complement(self) -> Self {
-        !self
-    }
+                fn complement(self) -> Self {
+                    !self
+                }
 
-    fn shift_start() -> Self {
-        1u8 << 7
-    }
+                fn shift_start() -> Self {
+                    1 << $shift_start_offset
+                }
 
-    fn zero() -> Self {
-        0
-    }
+                fn zero() -> Self {
+                    0
+                }
+            }
+
+        )*
+    };
 }
 
-impl BitTarget for u64 {
-    fn right_shift(self, by: usize) -> Self {
-        self >> by
-    }
-
-    fn and(self, value: Self) -> Self {
-        self & value
-    }
-
-    fn or(self, value: Self) -> Self {
-        self | value
-    }
-
-    fn complement(self) -> Self {
-        !self
-    }
-
-    fn shift_start() -> Self {
-        1u64 << 63
-    }
-
-    fn zero() -> Self {
-        0
-    }
+const fn shift_offset<T: Sized>() -> usize {
+    (size_of::<T>() * 8) - 1
 }
+
+const U8_SHIFT_OFFSET: usize = shift_offset::<u8>();
+const U16_SHIFT_OFFSET: usize = shift_offset::<u16>();
+const U32_SHIFT_OFFSET: usize = shift_offset::<u32>();
+const USIZE_SHIFT_OFFSET: usize = shift_offset::<usize>();
+const U64_SHIFT_OFFSET: usize = shift_offset::<u64>();
+
+bit_target_integer!(
+    u8 U8_SHIFT_OFFSET,
+    u16 U16_SHIFT_OFFSET,
+    u32 U32_SHIFT_OFFSET,
+    usize USIZE_SHIFT_OFFSET,
+    u64 U64_SHIFT_OFFSET,
+);
 
 pub const fn try_get_bit_start_offset(bit_count: usize, byte_count: usize) -> Option<usize> {
     let available_bits = byte_count * 8;

--- a/bst/src/bits.rs
+++ b/bst/src/bits.rs
@@ -16,7 +16,7 @@
 
 use core::mem::size_of;
 
-trait BitTarget: Sized + Eq {
+pub trait BitTarget: Sized + Eq + Copy {
     fn bits_per_digit() -> usize {
         size_of::<Self>() * 8
     }
@@ -96,7 +96,7 @@ pub const fn try_get_bit_start_offset(bit_count: usize, byte_count: usize) -> Op
     }
 }
 
-pub const fn try_get_bit_at_index<T: BitTarget>(bit_index: usize, digits: &[T]) -> Option<bool> {
+pub fn try_get_bit_at_index<T: BitTarget>(bit_index: usize, digits: &[T]) -> Option<bool> {
     let byte_index = bit_index / T::bits_per_digit();
     if byte_index >= digits.len() {
         return None;
@@ -104,7 +104,7 @@ pub const fn try_get_bit_at_index<T: BitTarget>(bit_index: usize, digits: &[T]) 
 
     let digit = digits[byte_index];
     let bit_index = bit_index % T::bits_per_digit();
-    let mut bit_mask = T::shift_start().right_shift(bit_index);
+    let bit_mask = T::shift_start().right_shift(bit_index);
     Some(digit.and(bit_mask) != T::zero())
 }
 
@@ -116,7 +116,7 @@ pub fn try_set_bit_at_index<T: BitTarget>(bit_index: usize, value: bool, bytes: 
 
     let byte = bytes[byte_index];
     let bit_index = bit_index % T::bits_per_digit();
-    let mut bit_mask = T::shift_start().right_shift(bit_index);
+    let bit_mask = T::shift_start().right_shift(bit_index);
     bytes[byte_index] = if value {
         byte.or(bit_mask)
     } else {

--- a/bst/src/bits.rs
+++ b/bst/src/bits.rs
@@ -124,3 +124,15 @@ pub fn try_set_bit_at_index<T: BitTarget>(bit_index: usize, value: bool, bytes: 
 
     true
 }
+
+pub fn first_high_bit_index<T: BitTarget>(digit: T) -> usize {
+    let mut first_high_bit_index = T::bits_per_digit() - 1;
+    for i in 0..first_high_bit_index {
+        if (digit.and(T::shift_start().right_shift(i))) != T::zero() {
+            first_high_bit_index = i;
+            break;
+        }
+    }
+
+    first_high_bit_index
+}

--- a/bst/src/bits.rs
+++ b/bst/src/bits.rs
@@ -37,7 +37,6 @@ pub trait BitTarget: Sized + Eq + Copy {
 macro_rules! bit_target_integer {
     ($($integer:ident $shift_start_offset:ident,)*) => {
         $(
-            #[allow(dead_code)]
             impl BitTarget for $integer {
                 fn right_shift(self, by: usize) -> Self {
                     self >> by

--- a/bst/src/console_out.rs
+++ b/bst/src/console_out.rs
@@ -51,11 +51,6 @@ impl ConsoleCursorState {
     pub const fn position(&self) -> Point {
         self.position
     }
-
-    #[allow(dead_code)]
-    pub const fn visible(&self) -> bool {
-        self.visible
-    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]

--- a/bst/src/cryptography/asymmetric/ecc/mod.rs
+++ b/bst/src/cryptography/asymmetric/ecc/mod.rs
@@ -23,7 +23,7 @@ pub use point::{EllipticCurvePoint, COMPRESSED_Y_IS_EVEN_IDENTIFIER};
 use crate::{
     bits::{try_get_bit_at_index, try_set_bit_at_index},
     global_runtime_immutable::GlobalRuntimeImmutable,
-    integers::{BigSigned, BigUnsigned, BigUnsignedCalculator},
+    integers::{BigSigned, BigUnsigned, BigUnsignedCalculator, Digit},
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::cmp::Ordering;
@@ -31,7 +31,7 @@ use core::cmp::Ordering;
 const PRIVATE_KEY_PREFIX: u8 = 0x00;
 
 static mut CUBE: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
-    GlobalRuntimeImmutable::from(|| BigUnsigned::from_be_bytes(&[0x03]));
+    GlobalRuntimeImmutable::from(|| BigUnsigned::from_digits(&[3]));
 
 pub struct EllipticCurvePointAdditionContext {
     unsigned_calculator: BigUnsignedCalculator,
@@ -85,7 +85,7 @@ pub struct EllipticCurvePointMultiplicationContext {
     i: &'static BigUnsigned,
     b: &'static BigUnsigned,
     n: &'static BigUnsigned,
-    bit_buffer: Vec<u8>,
+    bit_buffer: Vec<Digit>,
 }
 
 impl EllipticCurvePointMultiplicationContext {
@@ -105,7 +105,7 @@ impl EllipticCurvePointMultiplicationContext {
             addition_context: EllipticCurvePointAdditionContext::from(p, a, integer_capacity),
             side_channel_mitigation_point: EllipticCurvePoint::infinity(integer_capacity),
             working_point: EllipticCurvePoint::infinity(integer_capacity),
-            bit_buffer: vec![0u8; n.digit_count()],
+            bit_buffer: vec![0; n.digit_count()],
             comparison_box: Box::from(None),
             i,
             b,

--- a/bst/src/cryptography/asymmetric/ecc/mod.rs
+++ b/bst/src/cryptography/asymmetric/ecc/mod.rs
@@ -23,10 +23,10 @@ pub use point::{EllipticCurvePoint, COMPRESSED_Y_IS_EVEN_IDENTIFIER};
 use crate::{
     bits::{try_get_bit_at_index, try_set_bit_at_index},
     global_runtime_immutable::GlobalRuntimeImmutable,
-    integers::{BigSigned, BigUnsigned, BigUnsignedCalculator, Digit},
+    integers::{BigSigned, BigUnsigned, BigUnsignedCalculator, Digit, BITS_PER_DIGIT},
 };
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{cmp::Ordering, mem::size_of};
+use core::cmp::Ordering;
 
 const PRIVATE_KEY_PREFIX: u8 = 0x00;
 
@@ -260,9 +260,9 @@ impl EllipticCurvePointMultiplicationContext {
                 multiplier_digits[j]
             };
 
-            for j in 0..8 * size_of::<Digit>() {
+            for j in 0..BITS_PER_DIGIT {
                 assert!(try_set_bit_at_index(
-                    i * 8 * size_of::<Digit>() + j,
+                    i * BITS_PER_DIGIT + j,
                     try_get_bit_at_index(j, &[digit]).unwrap(),
                     &mut self.bit_buffer
                 ));
@@ -276,7 +276,7 @@ impl EllipticCurvePointMultiplicationContext {
         self.working_point.set_equal_to_unsigned(x, y);
 
         // Iterate over the bits in the multiplier from least to most significant.
-        for i in (0..self.bit_buffer.len() * size_of::<Digit>() * 8).rev() {
+        for i in (0..self.bit_buffer.len() * BITS_PER_DIGIT).rev() {
             if try_get_bit_at_index(i, &self.bit_buffer).unwrap() {
                 // The bit at the current index is high; we should add to our product.
                 product.add(&self.working_point, &mut self.addition_context);

--- a/bst/src/cryptography/asymmetric/ecc/point.rs
+++ b/bst/src/cryptography/asymmetric/ecc/point.rs
@@ -431,7 +431,7 @@ impl EllipticCurvePoint {
 
         // Y = Yp
         // Y *= 2
-        self.y.multiply_u8(2);
+        self.y.multiply_be_bytes_unsigned(&[2]);
 
         // Y mod inverse
         addition_context.mod_inverse(&mut self.y);
@@ -441,7 +441,7 @@ impl EllipticCurvePoint {
         self.x.multiply_big_signed(&addition_context.augend.x);
 
         // X *= 3
-        self.x.multiply_u8(3);
+        self.x.multiply_be_bytes_unsigned(&[3]);
 
         // X += a
         self.x.add_big_unsigned(addition_context.a);

--- a/bst/src/cryptography/asymmetric/ecc/point.rs
+++ b/bst/src/cryptography/asymmetric/ecc/point.rs
@@ -291,10 +291,10 @@ pub struct EllipticCurvePoint {
 }
 
 impl EllipticCurvePoint {
-    pub fn infinity(integer_capacity: usize) -> Self {
+    pub fn infinity(integer_byte_capacity: usize) -> Self {
         Self {
-            x: BigSigned::with_capacity(integer_capacity),
-            y: BigSigned::with_capacity(integer_capacity),
+            x: BigSigned::with_byte_capacity(integer_byte_capacity),
+            y: BigSigned::with_byte_capacity(integer_byte_capacity),
             is_infinity: true,
         }
     }

--- a/bst/src/cryptography/asymmetric/ecc/point.rs
+++ b/bst/src/cryptography/asymmetric/ecc/point.rs
@@ -320,7 +320,7 @@ impl EllipticCurvePoint {
         };
 
         // Copy the bytes from the X coordinate to the end of the buffer.
-        self.x.copy_be_bytes_to(&mut buffer[N - byte_count..]);
+        assert!(self.x.try_copy_be_bytes_to(&mut buffer[N - byte_count..]));
         Some(buffer)
     }
 

--- a/bst/src/cryptography/asymmetric/ecc/point.rs
+++ b/bst/src/cryptography/asymmetric/ecc/point.rs
@@ -299,14 +299,6 @@ impl EllipticCurvePoint {
         }
     }
 
-    pub fn from(x: BigSigned, y: BigSigned) -> Self {
-        Self {
-            is_infinity: x.is_zero() && y.is_zero(),
-            x,
-            y,
-        }
-    }
-
     pub fn try_serialize_compressed<const N: usize>(&self) -> Option<[u8; N]> {
         // We can compress a point on a prime finite field elliptic curve by representing it with only the X value,
         // and a single byte to indicate whether the Y value is odd or even, because there are two possible Y values
@@ -333,8 +325,9 @@ impl EllipticCurvePoint {
         Some(buffer)
     }
 
-    pub fn y(&self) -> &BigSigned {
-        &self.y
+    #[cfg(test)]
+    pub fn borrow_coordinates(&self) -> (&BigSigned, &BigSigned) {
+        (&self.x, &self.y)
     }
 
     pub fn add(

--- a/bst/src/cryptography/asymmetric/ecc/point.rs
+++ b/bst/src/cryptography/asymmetric/ecc/point.rs
@@ -303,7 +303,8 @@ impl EllipticCurvePoint {
         // We can compress a point on a prime finite field elliptic curve by representing it with only the X value,
         // and a single byte to indicate whether the Y value is odd or even, because there are two possible Y values
         // for any given X coordinate, and (mod p) results in one Y value always being even, and the other always being odd.
-        if self.x.byte_count() + 1 > N {
+        let byte_count = self.x.byte_count();
+        if byte_count + 1 > N {
             // We need to be able to fit X in the buffer, with one additional byte to spare. If we can't manage that, return None.
             return None;
         }
@@ -319,15 +320,8 @@ impl EllipticCurvePoint {
         };
 
         // Copy the bytes from the X coordinate to the end of the buffer.
-        self.x
-            .copy_be_bytes_to(&mut buffer[N - self.x.byte_count()..]);
-
+        self.x.copy_be_bytes_to(&mut buffer[N - byte_count..]);
         Some(buffer)
-    }
-
-    #[cfg(test)]
-    pub fn borrow_coordinates(&self) -> (&BigSigned, &BigSigned) {
-        (&self.x, &self.y)
     }
 
     pub fn add(

--- a/bst/src/cryptography/asymmetric/ecc/point.rs
+++ b/bst/src/cryptography/asymmetric/ecc/point.rs
@@ -303,7 +303,7 @@ impl EllipticCurvePoint {
         // We can compress a point on a prime finite field elliptic curve by representing it with only the X value,
         // and a single byte to indicate whether the Y value is odd or even, because there are two possible Y values
         // for any given X coordinate, and (mod p) results in one Y value always being even, and the other always being odd.
-        if self.x.digit_count() + 1 > N {
+        if self.x.byte_count() + 1 > N {
             // We need to be able to fit X in the buffer, with one additional byte to spare. If we can't manage that, return None.
             return None;
         }
@@ -320,7 +320,7 @@ impl EllipticCurvePoint {
 
         // Copy the bytes from the X coordinate to the end of the buffer.
         self.x
-            .copy_digits_to(&mut buffer[N - self.x.digit_count()..]);
+            .copy_be_bytes_to(&mut buffer[N - self.x.byte_count()..]);
 
         Some(buffer)
     }
@@ -431,7 +431,7 @@ impl EllipticCurvePoint {
 
         // Y = Yp
         // Y *= 2
-        self.y.multiply_be_bytes_unsigned(&[2]);
+        self.y.multiply_unsigned(&[2]);
 
         // Y mod inverse
         addition_context.mod_inverse(&mut self.y);
@@ -441,7 +441,7 @@ impl EllipticCurvePoint {
         self.x.multiply_big_signed(&addition_context.augend.x);
 
         // X *= 3
-        self.x.multiply_be_bytes_unsigned(&[3]);
+        self.x.multiply_unsigned(&[3]);
 
         // X += a
         self.x.add_big_unsigned(addition_context.a);

--- a/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
+++ b/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
@@ -35,7 +35,7 @@ static mut P: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
 static mut P_I: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
     GlobalRuntimeImmutable::from(|| {
         let mut i = p().clone();
-        i.add_u8(1);
+        i.add_be_bytes(&[1]);
         let mut r = 0u8;
         i.divide_u8_with_remainder(4, &mut r);
         i

--- a/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
+++ b/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
@@ -35,9 +35,9 @@ static mut P: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
 static mut P_I: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
     GlobalRuntimeImmutable::from(|| {
         let mut i = p().clone();
-        i.add_be_bytes(&[1]);
-        let mut r = 0u8;
-        i.divide_u8_with_remainder(4, &mut r);
+        i.add(&[1]);
+        let mut r = 0;
+        i.divide_by_single_digit_with_remainder(4, &mut r);
         i
     });
 

--- a/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
+++ b/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
@@ -86,7 +86,7 @@ static mut N: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
     });
 
 pub fn point_multiplication_context() -> EllipticCurvePointMultiplicationContext {
-    EllipticCurvePointMultiplicationContext::new(n(), p(), p_i(), a(), b(), 32)
+    EllipticCurvePointMultiplicationContext::new(n(), p(), p_i(), a(), b(), 8)
 }
 
 pub fn serialized_private_key_bytes(key: &[u8]) -> [u8; 33] {

--- a/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
+++ b/bst/src/cryptography/asymmetric/ecc/secp256k1.rs
@@ -86,7 +86,7 @@ static mut N: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
     });
 
 pub fn point_multiplication_context() -> EllipticCurvePointMultiplicationContext {
-    EllipticCurvePointMultiplicationContext::new(n(), p(), p_i(), a(), b(), 8)
+    EllipticCurvePointMultiplicationContext::new(64, n(), p(), p_i(), a(), b())
 }
 
 pub fn serialized_private_key_bytes(key: &[u8]) -> [u8; 33] {

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -959,7 +959,7 @@ impl BigUnsigned {
         // Trim any leading zeroes.
         let first_non_zero_byte_index = match Self::first_non_zero_byte_index(be_bytes) {
             Some(i) => i,
-            None => return (1, be_bytes),
+            None => return (1, &be_bytes[be_bytes.len()..]),
         };
 
         // Calculate the number of digits we need.

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use alloc::{boxed::Box, vec::Vec};
-use core::{cmp::Ordering, mem::size_of};
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 #[derive(Debug, Clone, Eq)]
 pub struct BigUnsigned {
@@ -134,15 +134,6 @@ impl BigSigned {
         }
     }
 
-    pub fn from_be_bytes(is_negative: bool, be_bytes: &[u8]) -> Self {
-        Self::from_unsigned(is_negative, BigUnsigned::from_be_bytes(be_bytes))
-    }
-
-    #[allow(dead_code)]
-    pub fn from_vec(is_negative: bool, digits: Vec<u8>) -> Self {
-        Self::from_unsigned(is_negative, BigUnsigned::from_vec(digits))
-    }
-
     pub fn with_capacity(capacity: usize) -> Self {
         Self::from_unsigned(false, BigUnsigned::with_capacity(capacity))
     }
@@ -159,10 +150,6 @@ impl BigUnsigned {
 
     pub fn copy_digits_to(&self, buffer: &mut [u8]) {
         buffer.copy_from_slice(&self.digits)
-    }
-
-    pub fn clone_be_bytes(&self) -> Box<[u8]> {
-        (&self.digits[..]).into()
     }
 
     pub fn borrow_digits(&self) -> &[u8] {
@@ -195,19 +182,9 @@ impl BigUnsigned {
         // We guarantee at least one digit. The final digit's final bit is all we need to check.
         self.digits[self.digits.len() - 1] & 1 == 0
     }
-
-    #[allow(dead_code)]
-    pub fn is_odd(&self) -> bool {
-        !self.is_even()
-    }
 }
 
 impl BigSigned {
-    #[allow(dead_code)]
-    pub fn extract_be_bytes(self) -> Vec<u8> {
-        self.big_unsigned.extract_be_bytes()
-    }
-
     pub fn borrow_unsigned_mut(&mut self) -> &mut BigUnsigned {
         &mut self.big_unsigned
     }
@@ -216,18 +193,8 @@ impl BigSigned {
         self.big_unsigned.copy_digits_to(buffer)
     }
 
-    #[allow(dead_code)]
     pub fn borrow_unsigned(&self) -> &BigUnsigned {
         &self.big_unsigned
-    }
-
-    pub fn clone_be_bytes(&self) -> Box<[u8]> {
-        self.big_unsigned.clone_be_bytes()
-    }
-
-    #[allow(dead_code)]
-    pub fn borrow_digits(&self) -> &[u8] {
-        self.big_unsigned.borrow_digits()
     }
 
     pub fn digit_count(&self) -> usize {
@@ -246,18 +213,8 @@ impl BigSigned {
         self.is_negative
     }
 
-    #[allow(dead_code)]
-    pub fn is_positive(&self) -> bool {
-        !self.is_negative
-    }
-
     pub fn is_even(&self) -> bool {
         self.big_unsigned.is_even()
-    }
-
-    #[allow(dead_code)]
-    pub fn is_odd(&self) -> bool {
-        !self.is_even()
     }
 }
 
@@ -335,340 +292,18 @@ impl BigSigned {
     }
 }
 
-//\/\/\/\///
-// Macros //
-//\/\/\/\///
-
-macro_rules! simple_operation_implement_unsigned_type {
-    ($(($digits_name:ident, $operation_name:ident): $operator_type:ty,)*) => {
-        $(
-            #[allow(dead_code)]
-            pub fn $operation_name(&mut self, operator: $operator_type) {
-                self.$digits_name(&operator.to_be_bytes())
-            }
-        )*
-    };
-}
-
-macro_rules! fallible_operation_implement_unsigned_type {
-    ($(($digits_name:ident, $operation_name:ident): $operator_type:ty,)*) => {
-        $(
-            #[allow(dead_code)]
-            pub fn $operation_name(&mut self, operator: $operator_type) -> bool {
-                self.$digits_name(&operator.to_be_bytes())
-            }
-        )*
-    };
-}
-
-macro_rules! simple_operation_implement_unsigned_types {
-    ($($digits_name:ident: $u8_name:ident, $u16_name:ident, $u32_name:ident, $usize_name:ident, $u64_name:ident, $u128_name:ident, $big_unsigned_name:ident,)*) => {
-    $(
-        simple_operation_implement_unsigned_type!(
-            ($digits_name, $u8_name): u8,
-            ($digits_name, $u16_name): u16,
-            ($digits_name, $u32_name): u32,
-            ($digits_name, $usize_name): usize,
-            ($digits_name, $u64_name): u64,
-            ($digits_name, $u128_name): u128,
-        );
-
-        #[allow(dead_code)]
-        pub fn $big_unsigned_name(&mut self, value: &BigUnsigned) {
-            self.$digits_name(&value.digits)
-        }
-    )*
-    }
-}
-
-macro_rules! fallible_operation_implement_unsigned_types {
-    ($($digits_name:ident: $u8_name:ident, $u16_name:ident, $u32_name:ident, $usize_name:ident, $u64_name:ident, $u128_name:ident, $big_unsigned_name:ident,)*) => {
-    $(
-        fallible_operation_implement_unsigned_type!(
-            ($digits_name, $u8_name): u8,
-            ($digits_name, $u16_name): u16,
-            ($digits_name, $u32_name): u32,
-            ($digits_name, $usize_name): usize,
-            ($digits_name, $u64_name): u64,
-            ($digits_name, $u128_name): u128,
-        );
-
-        #[allow(dead_code)]
-        pub fn $big_unsigned_name(&mut self, value: &BigUnsigned) -> bool {
-            self.$digits_name(&value.digits)
-        }
-    )*
-    }
-}
-
-macro_rules! simple_operation_implement_signed_type {
-    ($(($digits_name:ident, $operation_name:ident): $operator_type:ty,)*) => {
-        $(
-            #[allow(dead_code)]
-            pub fn $operation_name(&mut self, operator: $operator_type) {
-                self.$digits_name(&operator.unsigned_abs().to_be_bytes(), operator < 0)
-            }
-        )*
-    };
-}
-
-macro_rules! fallible_operation_implement_signed_type {
-    ($(($digits_name:ident, $operation_name:ident): $operator_type:ty,)*) => {
-        $(
-            #[allow(dead_code)]
-            pub fn $operation_name(&mut self, operator: $operator_type) -> bool {
-                self.$digits_name(&operator.unsigned_abs().to_be_bytes(), operator < 0)
-            }
-        )*
-    };
-}
-
-macro_rules! simple_operation_implement_signed_types {
-    ($($digits_name:ident: $i8_name:ident, $i16_name:ident, $i32_name:ident, $isize_name:ident, $i64_name:ident, $i128_name:ident, $big_unsigned_name:ident,)*) => {
-    $(
-        simple_operation_implement_signed_type!(
-            ($digits_name, $i8_name): i8,
-            ($digits_name, $i16_name): i16,
-            ($digits_name, $i32_name): i32,
-            ($digits_name, $isize_name): isize,
-            ($digits_name, $i64_name): i64,
-            ($digits_name, $i128_name): i128,
-        );
-
-        #[allow(dead_code)]
-        pub fn $big_unsigned_name(&mut self, value: &BigSigned) {
-            self.$digits_name(&value.big_unsigned.digits, value.is_negative)
-        }
-    )*
-    }
-}
-
-macro_rules! fallible_operation_implement_signed_types {
-    ($($digits_name:ident: $i8_name:ident, $i16_name:ident, $i32_name:ident, $isize_name:ident, $i64_name:ident, $i128_name:ident, $big_unsigned_name:ident,)*) => {
-    $(
-        fallible_operation_implement_signed_type!(
-            ($digits_name, $i8_name): i8,
-            ($digits_name, $i16_name): i16,
-            ($digits_name, $i32_name): i32,
-            ($digits_name, $isize_name): isize,
-            ($digits_name, $i64_name): i64,
-            ($digits_name, $i128_name): i128,
-        );
-
-        #[allow(dead_code)]
-        pub fn $big_unsigned_name(&mut self, value: &BigSigned) -> bool {
-            self.$digits_name(&value.big_unsigned.digits, value.is_negative)
-        }
-    )*
-    }
-}
-
-macro_rules! big_unsigned_division_implementation {
-    ($($division_name:ident: $division_type:ident, $remainder_buffer_size:expr,)*) => {
-    $(
-        #[allow(dead_code)]
-        pub fn $division_name(&mut self, divisor: $division_type, remainder_buffer: &mut $division_type) -> bool {
-            let mut remainder_bytes = [0u8; $remainder_buffer_size];
-            match self.divide_be_bytes_with_remainder(&divisor.to_be_bytes(), &mut remainder_bytes) {
-                true => {
-                    *remainder_buffer = $division_type::from_be_bytes(remainder_bytes);
-                    true
-                }
-                false => false,
-            }
-        }
-    )*
-    }
-}
-
-macro_rules! big_signed_division_implementation_for_unsigned_with_remainder {
-    ($($division_name:ident: $divisor_type:ty, $remainder_type:ty,)*) => {
-        $(
-            #[allow(dead_code)]
-            pub fn $division_name(
-                &mut self,
-                divisor: $divisor_type,
-                remainder_buffer: $remainder_type,
-                remainder_is_negative: &mut bool,
-            ) -> bool {
-                if self
-                    .big_unsigned
-                    .$division_name(divisor, remainder_buffer)
-                {
-                    *remainder_is_negative = self.is_negative;
-                    self.is_negative = self.is_negative && !self.is_zero();
-                    true
-                } else {
-                    false
-                }
-            }
-        )*
-        }
-}
-
-macro_rules! big_signed_division_implementation_for_signed_with_remainder {
-    ($(($division_name:ident, $unsigned_division_name:ident): $divisor_type:ty, $remainder_type:ty,)*) => {
-        $(
-            #[allow(dead_code)]
-            pub fn $division_name(&mut self, divisor: $divisor_type, remainder_buffer: $remainder_type) -> bool {
-                let mut unsigned_remainder = 0;
-                if self
-                    .big_unsigned
-                    .$unsigned_division_name(divisor.unsigned_abs(), &mut unsigned_remainder)
-                {
-                    *remainder_buffer = if self.is_negative {
-                        -(unsigned_remainder as $divisor_type)
-                    } else {
-                        unsigned_remainder as $divisor_type
-                    };
-
-                    self.is_negative = self.is_negative != (divisor < 0) && !self.is_zero();
-                    true
-                } else {
-                    false
-                }
-            }
-        )*
-        }
-}
-
-//\/\/\/\/\/\/\/\/\/\///
-// Logical Operations //
-//\/\/\/\/\/\/\/\/\/\///
-
-impl BigUnsigned {
-    simple_operation_implement_unsigned_types!(
-        and_be_bytes: and_u8, and_u16, and_u32, and_usize, and_u64, and_u128, and_big_unsigned,
-    );
-
-    pub fn and_be_bytes(&mut self, operator_digits: &[u8]) {
-        let operator_digits = match Self::first_non_zero_digit_index(operator_digits) {
-            Some(i) => &operator_digits[i..],
-            None => {
-                // The operator has no non-zero digits. We end up with zero as X & 0 = 0.
-                self.zero();
-                return;
-            }
-        };
-
-        let operand_digit_count = self.digit_count();
-        let (operand_digits, operator_digits) = if operator_digits.len() >= operand_digit_count {
-            // The operator has a digit length greater than or equal to the operand's digit length. We can ignore leading digits, as X & 0 = 0.
-            (
-                &mut self.digits[..],
-                &operator_digits[operator_digits.len() - operand_digit_count..],
-            )
-        } else {
-            // The operator has a digit length less than the operand's digit length. X & 0 = 0, so zero out the operand's leading digits.
-            let offset = operand_digit_count - operator_digits.len();
-            self.digits[..offset].fill(0);
-            (&mut self.digits[offset..], &operator_digits[..])
-        };
-
-        for i in 0..operator_digits.len() {
-            // Perform the AND on each overlapping digit.
-            operand_digits[i] &= operator_digits[i];
-        }
-
-        self.trim_leading_zeroes();
-    }
-
-    simple_operation_implement_unsigned_types!(
-        xor_be_bytes: xor_u8, xor_u16, xor_u32, xor_usize, xor_u64, xor_u128, xor_big_unsigned,
-    );
-
-    pub fn xor_be_bytes(&mut self, operator_digits: &[u8]) {
-        let (operand_digits, operator_digits) = match self.prepare_or_or_xor(operator_digits) {
-            Some(d) => d,
-            None => return,
-        };
-
-        for i in 0..operator_digits.len() {
-            // Perform the XOR on each overlapping digit.
-            operand_digits[i] ^= operator_digits[i];
-        }
-
-        self.trim_leading_zeroes();
-    }
-
-    simple_operation_implement_unsigned_types!(
-        or_be_bytes: or_u8, or_u16, or_u32, or_usize, or_u64, or_u128, or_big_unsigned,
-    );
-
-    pub fn or_be_bytes(&mut self, operator_digits: &[u8]) {
-        let (operand_digits, operator_digits) = match self.prepare_or_or_xor(operator_digits) {
-            Some(d) => d,
-            None => return,
-        };
-
-        for i in 0..operator_digits.len() {
-            // Perform the OR on each overlapping digit.
-            operand_digits[i] |= operator_digits[i];
-        } // OR can't zero out any digits, so there's no need to trim.
-    }
-}
-
-impl BigSigned {
-    simple_operation_implement_unsigned_types!(
-        and_be_bytes_unsigned: and_u8, and_u16, and_u32, and_usize, and_u64, and_u128, and_big_unsigned,
-    );
-
-    pub fn and_be_bytes_unsigned(&mut self, operator_digits: &[u8]) {
-        self.and_be_bytes_signed(operator_digits, false)
-    }
-
-    simple_operation_implement_signed_types!(
-        and_be_bytes_signed: and_i8, and_i16, and_i32, and_isize, and_i64, and_i128, and_big_signed,
-    );
-
-    pub fn and_be_bytes_signed(&mut self, operator_digits: &[u8], is_negative: bool) {
-        self.big_unsigned.and_be_bytes(operator_digits);
-        self.is_negative &= is_negative;
-    }
-
-    simple_operation_implement_unsigned_types!(
-        xor_be_bytes_unsigned: xor_u8, xor_u16, xor_u32, xor_usize, xor_u64, xor_u128, xor_big_unsigned,
-    );
-
-    pub fn xor_be_bytes_unsigned(&mut self, operator_digits: &[u8]) {
-        self.xor_be_bytes_signed(operator_digits, false)
-    }
-
-    simple_operation_implement_signed_types!(
-        xor_be_bytes_signed: xor_i8, xor_i16, xor_i32, xor_isize, xor_i64, xor_i128, xor_big_signed,
-    );
-
-    pub fn xor_be_bytes_signed(&mut self, operator_digits: &[u8], is_negative: bool) {
-        self.big_unsigned.xor_be_bytes(operator_digits);
-        self.is_negative ^= is_negative;
-    }
-
-    simple_operation_implement_unsigned_types!(
-        or_be_bytes_unsigned: or_u8, or_u16, or_u32, or_usize, or_u64, or_u128, or_big_unsigned,
-    );
-
-    pub fn or_be_bytes_unsigned(&mut self, operator_digits: &[u8]) {
-        self.or_be_bytes_signed(operator_digits, false)
-    }
-
-    simple_operation_implement_signed_types!(
-        or_be_bytes_signed: or_i8, or_i16, or_i32, or_isize, or_i64, or_i128, or_big_signed,
-    );
-
-    pub fn or_be_bytes_signed(&mut self, operator_digits: &[u8], is_negative: bool) {
-        self.big_unsigned.or_be_bytes(operator_digits);
-        self.is_negative |= is_negative;
-    }
-}
-
 //\/\/\/\/\/\///
 // Arithmetic //
 //\/\/\/\/\/\///
 
 impl BigUnsigned {
-    simple_operation_implement_unsigned_types!(
-        add_be_bytes: add_u8, add_u16, add_u32, add_usize, add_u64, add_u128, add_big_unsigned,
-    );
+    pub fn add_u8(&mut self, addend: u8) {
+        self.add_be_bytes(&[addend])
+    }
+
+    pub fn add_big_unsigned(&mut self, addend: &BigUnsigned) {
+        self.add_be_bytes(&addend.digits)
+    }
 
     pub fn add_be_bytes(&mut self, addend_digits: &[u8]) {
         let addend_digits = match Self::first_non_zero_digit_index(addend_digits) {
@@ -729,9 +364,9 @@ impl BigUnsigned {
         } // Adding can't result in leading zeroes where there were none, so there's no need to trim.
     }
 
-    simple_operation_implement_unsigned_types!(
-        subtract_be_bytes: subtract_u8, subtract_u16, subtract_u32, subtract_usize, subtract_u64, subtract_u128, subtract_big_unsigned,
-    );
+    pub fn subtract_big_unsigned(&mut self, subtrahend: &BigUnsigned) {
+        self.subtract_be_bytes(&subtrahend.digits)
+    }
 
     pub fn subtract_be_bytes(&mut self, subtrahend_digits: &[u8]) {
         if self.is_zero() {
@@ -758,9 +393,9 @@ impl BigUnsigned {
         }
     }
 
-    simple_operation_implement_unsigned_types!(
-        difference_be_bytes: difference_u8, difference_u16, difference_u32, difference_usize, difference_u64, difference_u128, difference_big_unsigned,
-    );
+    pub fn difference_big_unsigned(&mut self, operator: &BigUnsigned) {
+        self.difference_be_bytes(&operator.digits)
+    }
 
     pub fn difference_be_bytes(&mut self, operator_digits: &[u8]) {
         let operator_digits = match Self::first_non_zero_digit_index(operator_digits) {
@@ -834,9 +469,17 @@ impl BigUnsigned {
         }
     }
 
-    simple_operation_implement_unsigned_types!(
-        multiply_be_bytes: multiply_u8, multiply_u16, multiply_u32, multiply_usize, multiply_u64, multiply_u128, multiply_big_unsigned,
-    );
+    pub fn multiply_u8(&mut self, multiplier: u8) {
+        self.multiply_be_bytes(&[multiplier])
+    }
+
+    pub fn multiply_u16(&mut self, multiplier: u16) {
+        self.multiply_be_bytes(&multiplier.to_be_bytes())
+    }
+
+    pub fn multiply_big_unsigned(&mut self, multiplier: &BigUnsigned) {
+        self.multiply_be_bytes(&multiplier.digits)
+    }
 
     pub fn multiply_be_bytes(&mut self, multiplier_digits: &[u8]) {
         let multiplier_digits = match Self::first_non_zero_digit_index(multiplier_digits) {
@@ -951,14 +594,6 @@ impl BigUnsigned {
         return true;
     }
 
-    big_unsigned_division_implementation!(
-        divide_u16_with_remainder: u16, 2,
-        divide_u32_with_remainder: u32, 4,
-        divide_usize_with_remainder: usize, size_of::<usize>(),
-        divide_u64_with_remainder: u64, 8,
-        divide_u128_with_remainder: u128, 16,
-    );
-
     pub fn divide_big_unsigned_with_remainder(
         &mut self,
         divisor: &BigUnsigned,
@@ -1057,9 +692,9 @@ impl BigUnsigned {
         true
     }
 
-    fallible_operation_implement_unsigned_types!(
-        modulo_be_bytes: modulo_u8, modulo_u16, modulo_u32, modulo_usize, modulo_u64, modulo_u128, modulo_big_unsigned,
-    );
+    pub fn modulo_big_unsigned(&mut self, modulus: &BigUnsigned) -> bool {
+        self.modulo_be_bytes(&modulus.digits)
+    }
 
     pub fn modulo_be_bytes(&mut self, modulus_digits: &[u8]) -> bool {
         let divisor_digits = match Self::first_non_zero_digit_index(modulus_digits) {
@@ -1116,17 +751,13 @@ impl BigUnsigned {
 }
 
 impl BigSigned {
-    simple_operation_implement_unsigned_types!(
-        add_be_bytes_unsigned: add_u8, add_u16, add_u32, add_usize, add_u64, add_u128, add_big_unsigned,
-    );
+    pub fn add_big_unsigned(&mut self, addend: &BigUnsigned) {
+        self.add_be_bytes_unsigned(&addend.digits)
+    }
 
     pub fn add_be_bytes_unsigned(&mut self, addend_digits: &[u8]) {
         self.add_be_bytes_signed(addend_digits, false)
     }
-
-    simple_operation_implement_signed_types!(
-        add_be_bytes_signed: add_i8, add_i16, add_i32, add_isize, add_i64, add_i128, add_big_signed,
-    );
 
     pub fn add_be_bytes_signed(&mut self, addend_digits: &[u8], is_negative: bool) {
         if is_negative == self.is_negative {
@@ -1147,34 +778,22 @@ impl BigSigned {
         }
     }
 
-    simple_operation_implement_unsigned_types!(
-        subtract_be_bytes_unsigned: subtract_u8, subtract_u16, subtract_u32, subtract_usize, subtract_u64, subtract_u128, subtract_big_unsigned,
-    );
-
-    pub fn subtract_be_bytes_unsigned(&mut self, subtrahend_digits: &[u8]) {
-        self.subtract_be_bytes_signed(subtrahend_digits, false)
+    pub fn subtract_big_signed(&mut self, subtrahend: &BigSigned) {
+        self.subtract_be_bytes_signed(&subtrahend.big_unsigned.digits, subtrahend.is_negative)
     }
-
-    simple_operation_implement_signed_types!(
-        subtract_be_bytes_signed: subtract_i8, subtract_i16, subtract_i32, subtract_isize, subtract_i64, subtract_i128, subtract_big_signed,
-    );
 
     pub fn subtract_be_bytes_signed(&mut self, subtrahend_digits: &[u8], is_negative: bool) {
         // Subtracting a negative is addition, and adding a negative is subtraction. We can invert the subtrahend's sign and add it.
         self.add_be_bytes_signed(subtrahend_digits, !is_negative)
     }
 
-    simple_operation_implement_unsigned_types!(
-        difference_be_bytes_unsigned: difference_u8, difference_u16, difference_u32, difference_usize, difference_u64, difference_u128, difference_big_unsigned,
-    );
+    pub fn difference_big_unsigned(&mut self, operator: &BigUnsigned) {
+        self.difference_be_bytes_unsigned(&operator.digits)
+    }
 
     pub fn difference_be_bytes_unsigned(&mut self, operator_digits: &[u8]) {
         self.difference_be_bytes_signed(operator_digits, false)
     }
-
-    simple_operation_implement_signed_types!(
-        difference_be_bytes_signed: difference_i8, difference_i16, difference_i32, difference_isize, difference_i64, difference_i128, difference_big_signed,
-    );
 
     pub fn difference_be_bytes_signed(&mut self, operator_digits: &[u8], is_negative: bool) {
         if self.is_negative == is_negative {
@@ -1189,17 +808,17 @@ impl BigSigned {
         self.is_negative = false;
     }
 
-    simple_operation_implement_unsigned_types!(
-        multiply_be_bytes_unsigned: multiply_u8, multiply_u16, multiply_u32, multiply_usize, multiply_u64, multiply_u128, multiply_big_unsigned,
-    );
+    pub fn multiply_u8(&mut self, multiplier: u8) {
+        self.multiply_be_bytes_unsigned(&[multiplier])
+    }
 
     pub fn multiply_be_bytes_unsigned(&mut self, multiplier_digits: &[u8]) {
         self.multiply_be_bytes_signed(multiplier_digits, false)
     }
 
-    simple_operation_implement_signed_types!(
-        multiply_be_bytes_signed: multiply_i8, multiply_i16, multiply_i32, multiply_isize, multiply_i64, multiply_i128, multiply_big_signed,
-    );
+    pub fn multiply_big_signed(&mut self, multiplier: &BigSigned) {
+        self.multiply_be_bytes_signed(&multiplier.big_unsigned.digits, multiplier.is_negative)
+    }
 
     pub fn multiply_be_bytes_signed(&mut self, multiplier_digits: &[u8], is_negative: bool) {
         // The unsigned value will always just be the product.
@@ -1210,84 +829,18 @@ impl BigSigned {
         self.is_negative = self.is_negative != is_negative && !self.is_zero()
     }
 
-    big_signed_division_implementation_for_unsigned_with_remainder!(
-        divide_u8_with_remainder: u8, &mut u8,
-        divide_u16_with_remainder: u16, &mut u16,
-        divide_u32_with_remainder: u32, &mut u32,
-        divide_usize_with_remainder: usize, &mut usize,
-        divide_u64_with_remainder: u64, &mut u64,
-        divide_u128_with_remainder: u128, &mut u128,
-        divide_big_unsigned_with_remainder: &BigUnsigned, &mut BigUnsigned,
-        divide_be_bytes_with_remainder: &[u8], &mut [u8],
-    );
-
-    big_signed_division_implementation_for_signed_with_remainder!(
-        (divide_i8_with_remainder, divide_u8_with_remainder): i8, &mut i8,
-        (divide_i16_with_remainder, divide_u16_with_remainder): i16, &mut i16,
-        (divide_i32_with_remainder, divide_u32_with_remainder): i32, &mut i32,
-        (divide_isize_with_remainder, divide_usize_with_remainder): isize, &mut isize,
-        (divide_i64_with_remainder, divide_u64_with_remainder): i64, &mut i64,
-        (divide_i128_with_remainder, divide_u128_with_remainder): i128, &mut i128,
-    );
-
-    pub fn divide_big_signed_with_remainder(
-        &mut self,
-        divisor: &BigSigned,
-        remainder_buffer: &mut BigSigned,
-    ) -> bool {
-        if self.big_unsigned.divide_big_unsigned_with_remainder(
-            &divisor.big_unsigned,
-            &mut remainder_buffer.big_unsigned,
-        ) {
-            remainder_buffer.is_negative = self.is_negative && !remainder_buffer.is_zero();
-            self.is_negative = self.is_negative != divisor.is_negative && !self.is_zero();
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn divide_big_signed_with_modulus(
-        &mut self,
-        divisor: &BigSigned,
-        modulus_buffer: &mut BigSigned,
-    ) -> bool {
-        let dividend_was_negative = self.is_negative;
-        if self.divide_big_signed_with_remainder(divisor, modulus_buffer) {
-            if modulus_buffer.is_non_zero() {
-                if dividend_was_negative != divisor.is_negative {
-                    modulus_buffer
-                        .big_unsigned
-                        .difference_big_unsigned(&divisor.big_unsigned);
-                }
-
-                modulus_buffer.is_negative = divisor.is_negative;
-            }
-
-            true
-        } else {
-            false
-        }
-    }
-
-    pub fn divide_big_unsigned_with_modulus(
+    pub fn divide_big_unsigned_with_remainder(
         &mut self,
         divisor: &BigUnsigned,
-        modulus_buffer: &mut BigUnsigned,
+        remainder_buffer: &mut BigUnsigned,
+        remainder_is_negative: &mut bool,
     ) -> bool {
-        let dividend_was_negative = self.is_negative;
-        let mut remainder_is_negative = false;
-        if self.divide_big_unsigned_with_remainder(
-            divisor,
-            modulus_buffer,
-            &mut remainder_is_negative,
-        ) {
-            if modulus_buffer.is_non_zero() {
-                if dividend_was_negative {
-                    modulus_buffer.difference_big_unsigned(&divisor);
-                }
-            }
-
+        if self
+            .big_unsigned
+            .divide_big_unsigned_with_remainder(divisor, remainder_buffer)
+        {
+            *remainder_is_negative = self.is_negative;
+            self.is_negative = self.is_negative && !self.is_zero();
             true
         } else {
             false
@@ -1309,42 +862,8 @@ impl BigSigned {
             modulus_buffer.is_negative = false;
             if modulus_buffer.is_non_zero() {
                 if dividend_was_negative {
-                    modulus_buffer.difference_big_unsigned(&divisor);
+                    modulus_buffer.difference_big_unsigned(divisor);
                 }
-            }
-
-            true
-        } else {
-            false
-        }
-    }
-
-    fallible_operation_implement_unsigned_types!(
-        modulo_be_bytes_unsigned: modulo_u8, modulo_u16, modulo_u32, modulo_usize, modulo_u64, modulo_u128, modulo_big_unsigned,
-    );
-
-    pub fn modulo_be_bytes_unsigned(&mut self, modulus_digits: &[u8]) -> bool {
-        self.modulo_be_bytes_signed(modulus_digits, false)
-    }
-
-    fallible_operation_implement_signed_types!(
-        modulo_be_bytes_signed: modulo_i8, modulo_i16, modulo_i32, modulo_isize, modulo_i64, modulo_i128, modulo_big_signed,
-    );
-
-    pub fn modulo_be_bytes_signed(
-        &mut self,
-        modulus_digits: &[u8],
-        modulus_is_negative: bool,
-    ) -> bool {
-        if self.big_unsigned.modulo_be_bytes(modulus_digits) {
-            if self.is_non_zero() {
-                if self.is_negative != modulus_is_negative {
-                    self.big_unsigned.difference_be_bytes(modulus_digits);
-                }
-
-                self.is_negative = modulus_is_negative;
-            } else {
-                self.is_negative = false;
             }
 
             true
@@ -1410,37 +929,6 @@ impl BigUnsigned {
     //\/\/\/\/\/\/\/\/\/\/\/\/\//
     // INSTANCE HELPER METHODS //
     //\/\/\/\/\/\/\/\/\/\/\/\/\//
-
-    fn prepare_or_or_xor<'a>(
-        &'a mut self,
-        operator_digits: &'a [u8],
-    ) -> Option<(&'a mut [u8], &'a [u8])> {
-        let operator_digits = match Self::first_non_zero_digit_index(operator_digits) {
-            Some(i) => &operator_digits[i..],
-            None => {
-                // The operator has no non-zero digits. This is a no-op as X | 0 = X, and X ^ 0 = X.
-                return None;
-            }
-        };
-
-        Some(if operator_digits.len() >= self.digits.len() {
-            // The operator has a digit length greater than or equal to the operand's digit length.
-            // Pre-pend the operand with the operator's leading digits as X | 0 = X, and X ^ 0 = X.
-            let offset = operator_digits.len() - self.digits.len();
-            self.digits
-                .splice(0..0, operator_digits[..offset].iter().cloned());
-
-            (&mut self.digits[offset..], &operator_digits[offset..])
-        } else {
-            // The operator has a digit length less than the operand's digit length. X | 0 = X, and X ^ 0 = X, so skip the operand's leading digits.
-            let digit_count = self.digit_count();
-            (
-                &mut self.digits[digit_count - operator_digits.len()..],
-                operator_digits,
-            )
-        })
-    }
-
     fn handle_remainder_equals_divisor(
         &mut self,
         quotient_digit: u8,

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -180,17 +180,6 @@ impl BigUnsigned {
         digits.push(0);
         Self { digits }
     }
-
-    pub fn from_vec(digits: Vec<Digit>) -> Self {
-        let mut value = Self { digits };
-        if value.digit_count() == 0 {
-            value.digits.push(0);
-        } else {
-            value.trim_leading_zeroes();
-        }
-
-        value
-    }
 }
 
 impl BigSigned {

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -17,10 +17,10 @@
 use alloc::{vec, vec::Vec};
 use core::{cmp::Ordering, mem::size_of};
 
-pub type Digit = u64;
 pub const DIGIT_SHIFT: usize = size_of::<Digit>() * 8;
+pub type Digit = u8;
 
-type Carry = u128;
+type Carry = u16;
 
 #[derive(Debug, Clone, Eq)]
 pub struct BigUnsigned {

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -17,9 +17,10 @@
 use alloc::vec::Vec;
 use core::{cmp::Ordering, mem::size_of};
 
-type Digit = u64;
+pub type Digit = u64;
+pub const DIGIT_SHIFT: usize = size_of::<Digit>() * 8;
+
 type Carry = u128;
-const DIGIT_SHIFT: usize = size_of::<Digit>() * 8;
 
 #[derive(Debug, Clone, Eq)]
 pub struct BigUnsigned {
@@ -100,6 +101,10 @@ impl Ord for BigSigned {
 //\/\/\/\/\/\/\///
 
 impl BigUnsigned {
+    pub fn from_be_bytes(be_bytes: &[u8]) -> Self {
+        todo!()
+    }
+
     pub fn from_digits(digits: &[Digit]) -> Self {
         Self {
             digits: match Self::first_non_zero_digit_index(digits) {
@@ -156,12 +161,20 @@ impl BigUnsigned {
         buffer.copy_from_slice(&self.digits)
     }
 
+    pub fn copy_be_bytes_to(&self, buffer: &mut [u8]) {
+        todo!()
+    }
+
     pub fn borrow_digits(&self) -> &[Digit] {
         &self.digits
     }
 
     pub fn digit_count(&self) -> usize {
         self.digits.len()
+    }
+
+    pub fn byte_count(&self) -> usize {
+        todo!()
     }
 
     pub fn is_non_zero(&self) -> bool {
@@ -197,12 +210,20 @@ impl BigSigned {
         self.big_unsigned.copy_digits_to(buffer)
     }
 
+    pub fn copy_be_bytes_to(&self, buffer: &mut [u8]) {
+        todo!()
+    }
+
     pub fn borrow_unsigned(&self) -> &BigUnsigned {
         &self.big_unsigned
     }
 
     pub fn digit_count(&self) -> usize {
         self.big_unsigned.digit_count()
+    }
+
+    pub fn byte_count(&self) -> usize {
+        todo!()
     }
 
     pub fn is_non_zero(&self) -> bool {
@@ -227,6 +248,10 @@ impl BigSigned {
 //\/\/\/\/\/\/\/\///
 
 impl BigUnsigned {
+    pub fn copy_be_bytes_from(&mut self, be_bytes: &[u8]) {
+        todo!()
+    }
+
     pub fn copy_digits_from(&mut self, digits: &[Digit]) {
         let digits = match Self::first_non_zero_digit_index(digits) {
             Some(i) => &digits[i..],
@@ -267,6 +292,11 @@ impl BigUnsigned {
 }
 
 impl BigSigned {
+    pub fn copy_be_bytes_from(&mut self, be_bytes: &[u8], is_negative: bool) {
+        self.big_unsigned.copy_be_bytes_from(be_bytes);
+        self.is_negative = is_negative;
+    }
+
     pub fn copy_digits_from(&mut self, digits: &[Digit], is_negative: bool) {
         self.big_unsigned.copy_digits_from(digits);
         self.is_negative = is_negative;

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -101,7 +101,7 @@ impl Ord for BigSigned {
 //\/\/\/\/\/\/\///
 
 impl BigUnsigned {
-    pub fn from_be_bytes(be_bytes: &[u8]) -> Self {
+    pub fn from_be_bytes(_be_bytes: &[u8]) -> Self {
         todo!()
     }
 
@@ -153,15 +153,7 @@ impl BigSigned {
 //\/\/\/\/\/\/\/\//
 
 impl BigUnsigned {
-    pub fn extract_digits(self) -> Vec<Digit> {
-        self.digits
-    }
-
-    pub fn copy_digits_to(&self, buffer: &mut [Digit]) {
-        buffer.copy_from_slice(&self.digits)
-    }
-
-    pub fn copy_be_bytes_to(&self, buffer: &mut [u8]) {
+    pub fn copy_be_bytes_to(&self, _buffer: &mut [u8]) {
         todo!()
     }
 
@@ -206,24 +198,16 @@ impl BigSigned {
         &mut self.big_unsigned
     }
 
-    pub fn copy_digits_to(&self, buffer: &mut [Digit]) {
-        self.big_unsigned.copy_digits_to(buffer)
-    }
-
     pub fn copy_be_bytes_to(&self, buffer: &mut [u8]) {
-        todo!()
+        self.big_unsigned.copy_be_bytes_to(buffer)
     }
 
     pub fn borrow_unsigned(&self) -> &BigUnsigned {
         &self.big_unsigned
     }
 
-    pub fn digit_count(&self) -> usize {
-        self.big_unsigned.digit_count()
-    }
-
     pub fn byte_count(&self) -> usize {
-        todo!()
+        self.big_unsigned.byte_count()
     }
 
     pub fn is_non_zero(&self) -> bool {
@@ -248,7 +232,7 @@ impl BigSigned {
 //\/\/\/\/\/\/\/\///
 
 impl BigUnsigned {
-    pub fn copy_be_bytes_from(&mut self, be_bytes: &[u8]) {
+    pub fn copy_be_bytes_from(&mut self, _be_bytes: &[u8]) {
         todo!()
     }
 

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -297,10 +297,6 @@ impl BigSigned {
 //\/\/\/\/\/\///
 
 impl BigUnsigned {
-    pub fn add_u8(&mut self, addend: u8) {
-        self.add_be_bytes(&[addend])
-    }
-
     pub fn add_big_unsigned(&mut self, addend: &BigUnsigned) {
         self.add_be_bytes(&addend.digits)
     }
@@ -467,14 +463,6 @@ impl BigUnsigned {
                 self.trim_leading_zeroes();
             }
         }
-    }
-
-    pub fn multiply_u8(&mut self, multiplier: u8) {
-        self.multiply_be_bytes(&[multiplier])
-    }
-
-    pub fn multiply_u16(&mut self, multiplier: u16) {
-        self.multiply_be_bytes(&multiplier.to_be_bytes())
     }
 
     pub fn multiply_big_unsigned(&mut self, multiplier: &BigUnsigned) {
@@ -806,10 +794,6 @@ impl BigSigned {
 
         // Differences are an absolute value.
         self.is_negative = false;
-    }
-
-    pub fn multiply_u8(&mut self, multiplier: u8) {
-        self.multiply_be_bytes_unsigned(&[multiplier])
     }
 
     pub fn multiply_be_bytes_unsigned(&mut self, multiplier_digits: &[u8]) {

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -286,12 +286,14 @@ impl BigUnsigned {
         // Calculate the number of required digits, and trim leading zeroes from the input bytes.
         let (digit_count, be_bytes) = Self::calculate_required_digits_for_bytes(be_bytes);
 
+        // Zero existing digits.
+        self.digits.fill(0);
+
         // Match the internal digit buffer to the required digit length.
         if self.digits.len() < digit_count {
             self.digits
                 .extend((0..digit_count - self.digits.len()).into_iter().map(|_| 0));
         } else {
-            self.digits[digit_count..].fill(0);
             self.digits.truncate(digit_count);
         }
 
@@ -341,11 +343,6 @@ impl BigUnsigned {
 impl BigSigned {
     pub fn copy_be_bytes_from(&mut self, be_bytes: &[u8], is_negative: bool) {
         self.big_unsigned.copy_be_bytes_from(be_bytes);
-        self.is_negative = is_negative;
-    }
-
-    pub fn copy_digits_from(&mut self, digits: &[Digit], is_negative: bool) {
-        self.big_unsigned.copy_digits_from(digits);
         self.is_negative = is_negative;
     }
 

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -16,7 +16,7 @@
 
 use crate::bits::first_high_bit_index;
 use alloc::{vec, vec::Vec};
-use core::{cmp::Ordering, mem::size_of, panic};
+use core::{cmp::Ordering, mem::size_of};
 
 #[cfg(target_pointer_width = "8")]
 pub type Digit = u8;
@@ -42,7 +42,7 @@ pub const BITS_PER_DIGIT: usize = size_of::<Digit>() * 8;
 
 #[derive(Debug, Clone, Eq)]
 pub struct BigUnsigned {
-    // We store digits in big-endian format, in base-2^64.
+    // We store digits in big-endian format, in base-2^X, where X is the bit length of the native pointer type.
     digits: Vec<Digit>,
 }
 
@@ -174,10 +174,10 @@ impl BigSigned {
 //\/\/\/\/\/\/\/\//
 
 impl BigUnsigned {
-    pub fn copy_be_bytes_to(&self, buffer: &mut [u8]) {
+    pub fn try_copy_be_bytes_to(&self, buffer: &mut [u8]) -> bool {
         let byte_count = self.byte_count();
         if buffer.len() < byte_count {
-            panic!("Tried to copy big-endian bytes out of a BigUnsigned to a buffer whose length was too short.");
+            return false;
         }
 
         // Zero out the buffer.
@@ -213,6 +213,8 @@ impl BigUnsigned {
 
             digit_index += 1;
         }
+
+        true
     }
 
     pub fn borrow_digits(&self) -> &[Digit] {
@@ -257,12 +259,12 @@ impl BigUnsigned {
 }
 
 impl BigSigned {
-    pub fn borrow_unsigned_mut(&mut self) -> &mut BigUnsigned {
-        &mut self.big_unsigned
+    pub fn try_copy_be_bytes_to(&self, buffer: &mut [u8]) -> bool {
+        self.big_unsigned.try_copy_be_bytes_to(buffer)
     }
 
-    pub fn copy_be_bytes_to(&self, buffer: &mut [u8]) {
-        self.big_unsigned.copy_be_bytes_to(buffer)
+    pub fn borrow_unsigned_mut(&mut self) -> &mut BigUnsigned {
+        &mut self.big_unsigned
     }
 
     pub fn borrow_unsigned(&self) -> &BigUnsigned {

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -20,6 +20,7 @@ use core::{cmp::Ordering, mem::size_of};
 pub const DIGIT_SHIFT: usize = size_of::<Digit>() * 8;
 pub type Digit = u8;
 
+// Must be larger than Digit.
 type Carry = u16;
 
 #[derive(Debug, Clone, Eq)]

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -182,7 +182,7 @@ impl BigUnsigned {
         if partial_digit_bytes != 0 {
             // The first digit has leading zero bytes; write that first.
             let first_digit_bytes = self.digits[0].to_be_bytes();
-            for i in size_of::<Digit>() - partial_digit_bytes.. {
+            for i in size_of::<Digit>() - partial_digit_bytes..size_of::<Digit>() {
                 buffer[buffer_index] = first_digit_bytes[i];
                 buffer_index += 1;
             }
@@ -982,7 +982,7 @@ impl BigUnsigned {
 
             // Increment the current byte index.
             current_byte_index += 1;
-            if current_byte_index == size_of::<Digit>() {
+            if current_byte_index == size_of::<Digit>() && i != 0 {
                 // If we've written a whole digit, move to the next digit and reset the byte index.
                 current_digit_index -= 1;
                 current_byte_index = 0;

--- a/bst/src/integers/big_integers.rs
+++ b/bst/src/integers/big_integers.rs
@@ -18,10 +18,10 @@ use alloc::{vec, vec::Vec};
 use core::{cmp::Ordering, mem::size_of, panic};
 
 pub const DIGIT_SHIFT: usize = size_of::<Digit>() * 8;
-pub type Digit = u8;
+pub type Digit = u64;
 
-// Must be larger than Digit.
-type Carry = u16;
+// Integer format must be 2x larger than Digit.
+type Carry = u128;
 
 const BITS_PER_DIGIT: usize = size_of::<Digit>() * 8;
 const DIGIT_SHIFT_START: Digit = 1 << (BITS_PER_DIGIT - 1);
@@ -744,6 +744,7 @@ impl BigUnsigned {
                 remainder_buffer[remainder_length - i..].copy_from_slice(&self.digits[..i]);
 
                 // Trim away the remainder, yielding the quotient.
+                self.digits[0..i].fill(0);
                 self.digits.drain(0..i);
                 self.trim_leading_zeroes();
             }
@@ -770,7 +771,11 @@ impl BigUnsigned {
             DivisionResult::SingleSubtraction => self.subtract(modulus_digits), // Subtract the divisor from the dividend to yield the remainder.
             DivisionResult::FullDivision(i) => {
                 // Drop the quotient.
+                self.digits[i..].fill(0);
                 self.digits.truncate(i);
+                if self.digits.len() == 0 {
+                    self.digits.push(0)
+                }
             }
         };
 

--- a/bst/src/integers/big_unsigned_calculator.rs
+++ b/bst/src/integers/big_unsigned_calculator.rs
@@ -161,7 +161,15 @@ impl BigUnsignedCalculator {
 
         let e = exponent.borrow_digits();
         let bit_count = e.len() * size_of::<Digit>() * 8;
-        for i in (0..bit_count).rev() {
+        let mut first_high_bit = bit_count;
+        for i in 0..bit_count {
+            if try_get_bit_at_index(i, e).unwrap() {
+                first_high_bit = i;
+                break;
+            }
+        }
+
+        for i in (first_high_bit..bit_count).rev() {
             if try_get_bit_at_index(i, e).unwrap() {
                 self.x.multiply_big_unsigned(&value);
                 self.x.modulo_big_unsigned(modulus);

--- a/bst/src/integers/big_unsigned_calculator.rs
+++ b/bst/src/integers/big_unsigned_calculator.rs
@@ -27,14 +27,14 @@ pub struct BigUnsignedCalculator {
 }
 
 impl BigUnsignedCalculator {
-    pub fn new(internal_integer_initial_capacities: usize) -> Self {
+    pub fn new(integer_byte_capacity: usize) -> Self {
         Self {
-            a: BigUnsigned::with_capacity(internal_integer_initial_capacities),
-            m: BigUnsigned::with_capacity(internal_integer_initial_capacities),
-            x: BigUnsigned::with_capacity(internal_integer_initial_capacities),
-            y: BigUnsigned::with_capacity(internal_integer_initial_capacities),
-            q: BigUnsigned::with_capacity(internal_integer_initial_capacities),
-            r: BigUnsigned::with_capacity(internal_integer_initial_capacities),
+            a: BigUnsigned::with_byte_capacity(integer_byte_capacity),
+            m: BigUnsigned::with_byte_capacity(integer_byte_capacity),
+            x: BigUnsigned::with_byte_capacity(integer_byte_capacity),
+            y: BigUnsigned::with_byte_capacity(integer_byte_capacity),
+            q: BigUnsigned::with_byte_capacity(integer_byte_capacity),
+            r: BigUnsigned::with_byte_capacity(integer_byte_capacity),
         }
     }
 

--- a/bst/src/integers/big_unsigned_calculator.rs
+++ b/bst/src/integers/big_unsigned_calculator.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::BigUnsigned;
+use super::{BigUnsigned, Digit};
 use crate::bits::try_get_bit_at_index;
+use core::mem::size_of;
 
 pub struct BigUnsignedCalculator {
     a: BigUnsigned,
@@ -159,7 +160,7 @@ impl BigUnsignedCalculator {
         self.x.one();
 
         let e = exponent.borrow_digits();
-        let bit_count = e.len() * 8;
+        let bit_count = e.len() * size_of::<Digit>() * 8;
         for i in (0..bit_count).rev() {
             if try_get_bit_at_index(i, e).unwrap() {
                 self.x.multiply_big_unsigned(&value);

--- a/bst/src/integers/big_unsigned_calculator.rs
+++ b/bst/src/integers/big_unsigned_calculator.rs
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::{BigUnsigned, Digit};
-use crate::bits::try_get_bit_at_index;
-use core::mem::size_of;
+use super::{BigUnsigned, BITS_PER_DIGIT};
+use crate::bits::{first_high_bit_index, try_get_bit_at_index};
 
 pub struct BigUnsignedCalculator {
     a: BigUnsigned,
@@ -160,15 +159,8 @@ impl BigUnsignedCalculator {
         self.x.one();
 
         let e = exponent.borrow_digits();
-        let bit_count = e.len() * size_of::<Digit>() * 8;
-        let mut first_high_bit = bit_count;
-        for i in 0..bit_count {
-            if try_get_bit_at_index(i, e).unwrap() {
-                first_high_bit = i;
-                break;
-            }
-        }
-
+        let bit_count = e.len() * BITS_PER_DIGIT;
+        let first_high_bit = first_high_bit_index(e[0]);
         for i in (first_high_bit..bit_count).rev() {
             if try_get_bit_at_index(i, e).unwrap() {
                 self.x.multiply_big_unsigned(&value);

--- a/bst/src/integers/mod.rs
+++ b/bst/src/integers/mod.rs
@@ -19,7 +19,7 @@ mod big_unsigned_calculator;
 mod numeric_base;
 mod numeric_collector;
 
-pub use big_integers::{BigSigned, BigUnsigned};
+pub use big_integers::{BigSigned, BigUnsigned, Digit, DIGIT_SHIFT};
 pub use big_unsigned_calculator::BigUnsignedCalculator;
 pub use numeric_base::{NumericBase, NumericBaseWithCharacterPredicate, NumericBases};
 pub use numeric_collector::{

--- a/bst/src/integers/mod.rs
+++ b/bst/src/integers/mod.rs
@@ -19,7 +19,7 @@ mod big_unsigned_calculator;
 mod numeric_base;
 mod numeric_collector;
 
-pub use big_integers::{BigSigned, BigUnsigned, Digit, DIGIT_SHIFT};
+pub use big_integers::{BigSigned, BigUnsigned, Digit, BITS_PER_DIGIT};
 pub use big_unsigned_calculator::BigUnsignedCalculator;
 pub use numeric_base::{NumericBase, NumericBaseWithCharacterPredicate, NumericBases};
 pub use numeric_collector::{

--- a/bst/src/integers/numeric_base.rs
+++ b/bst/src/integers/numeric_base.rs
@@ -16,7 +16,8 @@
 
 use super::BigUnsigned;
 use crate::{
-    characters::Character, console_out::ConsoleOut, ui::console::ConsoleWriteable, String16,
+    characters::Character, console_out::ConsoleOut, integers::Digit, ui::console::ConsoleWriteable,
+    String16,
 };
 use alloc::vec::Vec;
 use macros::{s16, u16_array};
@@ -275,11 +276,13 @@ impl NumericBase {
         null_terminate: bool,
         pad_to_length: usize,
     ) -> Vec<u16> {
-        let mut remainder = 0u8;
+        let mut remainder = 0;
         let mut vec = Vec::new();
         // Pop the next digit off the unsigned integer.
         while unsigned_integer.is_non_zero() {
-            assert!(unsigned_integer.divide_u8_with_remainder(self.base, &mut remainder));
+            assert!(unsigned_integer
+                .divide_by_single_digit_with_remainder(self.base as Digit, &mut remainder));
+
             // We're working from right to left, so we insert at 0.
             vec.insert(0, self.characters[remainder as usize]);
         }

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -48,14 +48,14 @@ pub struct NumericCollector {
 impl NumericCollector {
     pub fn with_byte_capacity(capacity: usize) -> Self {
         Self {
-            big_unsigned: BigUnsigned::with_capacity(capacity / size_of::<Digit>()),
+            big_unsigned: BigUnsigned::with_byte_capacity(capacity),
             bit_counter: 0f64,
         }
     }
 
     pub fn new() -> Self {
         Self {
-            big_unsigned: BigUnsigned::with_capacity(1),
+            big_unsigned: BigUnsigned::with_byte_capacity(8),
             bit_counter: 0f64,
         }
     }

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -81,16 +81,16 @@ impl NumericCollector {
                     // Push a digit to the end of the unsigned integer.
                     let bits = BASE_BITS_PER_ROUND[(round_base - 2) as usize];
                     self.bit_counter += bits;
-                    self.big_unsigned.multiply_u8(round_base);
-                    self.big_unsigned.add_u8(round_value);
+                    self.big_unsigned.multiply_be_bytes(&[round_base]);
+                    self.big_unsigned.add_be_bytes(&[round_value]);
                     Ok((bits, self.bit_counter))
                 }
             }
             NumericCollectorRoundBase::WholeByte => {
                 // Push a digit to the end of the unsigned integer.
                 self.bit_counter += 8f64;
-                self.big_unsigned.multiply_u16(256);
-                self.big_unsigned.add_u8(round_value);
+                self.big_unsigned.multiply_be_bytes(&[1, 0]);
+                self.big_unsigned.add_be_bytes(&[round_value]);
                 Ok((8f64, self.bit_counter))
             }
         }

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -105,7 +105,9 @@ impl NumericCollector {
 
     pub fn copy_padded_bytes_to(&self, buffer: &mut [u8]) {
         let padding = self.padded_byte_count() - self.trimmed_byte_count();
-        self.big_unsigned.copy_be_bytes_to(&mut buffer[padding..]);
+        assert!(self
+            .big_unsigned
+            .try_copy_be_bytes_to(&mut buffer[padding..]));
         // Make sure our leading zeroes are actually zeroes.
         buffer[..padding].fill(0);
     }

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::ceil;
+use super::{ceil, Digit};
 use crate::integers::BigUnsigned;
 use macros::log2_range;
 
@@ -81,16 +81,16 @@ impl NumericCollector {
                     // Push a digit to the end of the unsigned integer.
                     let bits = BASE_BITS_PER_ROUND[(round_base - 2) as usize];
                     self.bit_counter += bits;
-                    self.big_unsigned.multiply_be_bytes(&[round_base]);
-                    self.big_unsigned.add_be_bytes(&[round_value]);
+                    self.big_unsigned.multiply(&[round_base as Digit]);
+                    self.big_unsigned.add(&[round_value as Digit]);
                     Ok((bits, self.bit_counter))
                 }
             }
             NumericCollectorRoundBase::WholeByte => {
                 // Push a digit to the end of the unsigned integer.
                 self.bit_counter += 8f64;
-                self.big_unsigned.multiply_be_bytes(&[1, 0]);
-                self.big_unsigned.add_be_bytes(&[round_value]);
+                self.big_unsigned.multiply(&[256]);
+                self.big_unsigned.add(&[round_value as Digit]);
                 Ok((8f64, self.bit_counter))
             }
         }
@@ -98,13 +98,13 @@ impl NumericCollector {
 
     pub fn copy_padded_bytes_to(&self, buffer: &mut [u8]) {
         let padding = self.padded_byte_count() - self.trimmed_byte_count();
-        self.big_unsigned.copy_digits_to(&mut buffer[padding..]);
+        self.big_unsigned.copy_be_bytes_to(&mut buffer[padding..]);
         // Make sure our leading zeroes are actually zeroes.
         buffer[..padding].fill(0);
     }
 
     pub fn trimmed_byte_count(&self) -> usize {
-        self.big_unsigned.digit_count()
+        self.big_unsigned.byte_count()
     }
 
     pub fn padded_byte_count(&self) -> usize {

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -19,6 +19,12 @@ use crate::integers::BigUnsigned;
 use core::mem::size_of;
 use macros::log2_range;
 
+const WHOLE_BYTE_MULTIPLIER: &[Digit] = if size_of::<Digit>() == 1 {
+    &[1, 0]
+} else {
+    &[255 + 1]
+};
+
 const BASE_BITS_PER_ROUND: [f64; 254] = log2_range!(256);
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
@@ -90,7 +96,7 @@ impl NumericCollector {
             NumericCollectorRoundBase::WholeByte => {
                 // Push a digit to the end of the unsigned integer.
                 self.bit_counter += 8f64;
-                self.big_unsigned.multiply(&[256]);
+                self.big_unsigned.multiply(WHOLE_BYTE_MULTIPLIER);
                 self.big_unsigned.add(&[round_value as Digit]);
                 Ok((8f64, self.bit_counter))
             }

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -16,6 +16,7 @@
 
 use super::{ceil, Digit};
 use crate::integers::BigUnsigned;
+use core::mem::size_of;
 use macros::log2_range;
 
 const BASE_BITS_PER_ROUND: [f64; 254] = log2_range!(256);
@@ -41,14 +42,14 @@ pub struct NumericCollector {
 impl NumericCollector {
     pub fn with_byte_capacity(capacity: usize) -> Self {
         Self {
-            big_unsigned: BigUnsigned::with_capacity(capacity),
+            big_unsigned: BigUnsigned::with_capacity(capacity / size_of::<Digit>()),
             bit_counter: 0f64,
         }
     }
 
     pub fn new() -> Self {
         Self {
-            big_unsigned: BigUnsigned::with_capacity(8),
+            big_unsigned: BigUnsigned::with_capacity(1),
             bit_counter: 0f64,
         }
     }

--- a/bst/src/integers/numeric_collector.rs
+++ b/bst/src/integers/numeric_collector.rs
@@ -16,40 +16,9 @@
 
 use super::ceil;
 use crate::integers::BigUnsigned;
-use alloc::boxed::Box;
 use macros::log2_range;
 
 const BASE_BITS_PER_ROUND: [f64; 254] = log2_range!(256);
-
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct CollectedNumericData<T> {
-    trimmed_byte_count: usize,
-    padded_byte_count: usize,
-    bit_count: f64,
-    data: T,
-}
-
-impl<T> CollectedNumericData<T> {
-    pub const fn trimmed_byte_count(&self) -> usize {
-        self.trimmed_byte_count
-    }
-
-    pub const fn padded_byte_count(&self) -> usize {
-        self.padded_byte_count
-    }
-
-    pub const fn bit_count(&self) -> f64 {
-        self.bit_count
-    }
-
-    pub const fn data(&self) -> &T {
-        &self.data
-    }
-
-    pub fn take_data_ownership(self) -> T {
-        self.data
-    }
-}
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 pub enum NumericCollectorRoundBase {
@@ -84,24 +53,8 @@ impl NumericCollector {
         }
     }
 
-    pub fn extract_trimmed_bytes(self) -> CollectedNumericData<Box<[u8]>> {
-        let trimmed_byte_count = self.trimmed_byte_count();
-        let padded_byte_count = self.padded_byte_count();
-        CollectedNumericData {
-            data: self.big_unsigned.extract_be_bytes().into(),
-            bit_count: self.bit_counter,
-            trimmed_byte_count,
-            padded_byte_count,
-        }
-    }
-
-    pub fn extract_big_unsigned(self) -> CollectedNumericData<BigUnsigned> {
-        CollectedNumericData {
-            trimmed_byte_count: self.trimmed_byte_count(),
-            padded_byte_count: self.padded_byte_count(),
-            bit_count: self.bit_counter,
-            data: self.big_unsigned,
-        }
+    pub fn extract_big_unsigned(self) -> BigUnsigned {
+        self.big_unsigned
     }
 
     pub const fn bit_counter(&self) -> f64 {

--- a/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
+++ b/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
@@ -117,7 +117,7 @@ impl<TSystemServices: SystemServices> Program
                             }
 
                             // Increment the oversized private key.
-                            b.add_u8(1);
+                            b.add_be_bytes(&[1]);
 
                             // Take back ownership of the hash buffer.
                             hash_buffer = integer.extract_be_bytes();

--- a/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
+++ b/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
@@ -118,7 +118,7 @@ impl<TSystemServices: SystemServices> Program
                                 )
                             }
 
-                            b.copy_be_bytes_to(&mut hash_input_buffer);
+                            assert!(b.try_copy_be_bytes_to(&mut hash_input_buffer));
                             hmac.write_hmac_to(&hash_input_buffer, &mut hash_buffer);
 
                             // Give the truncated hash buffer to our result buffer; we'll compare and,
@@ -154,7 +154,7 @@ impl<TSystemServices: SystemServices> Program
         };
 
         let mut private_key_bytes = vec![0u8; private_key.byte_count()];
-        private_key.copy_be_bytes_to(&mut private_key_bytes);
+        assert!(private_key.try_copy_be_bytes_to(&mut private_key_bytes));
         private_key.zero();
 
         write_bytes(

--- a/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
+++ b/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
@@ -18,7 +18,7 @@ use crate::{
     console_out::ConsoleOut,
     constants,
     hashing::{Hasher, Sha512},
-    integers::{BigUnsigned, Digit},
+    integers::BigUnsigned,
     programs::{
         console::{cryptography::asymmetric::prompt_for_curve_selection, write_bytes},
         Program, ProgramExitResult,
@@ -33,7 +33,7 @@ use crate::{
     String16,
 };
 use alloc::vec;
-use core::{cmp::Ordering, mem::size_of};
+use core::cmp::Ordering;
 use macros::s16;
 
 const ITERATIVE_HASHING_KEY: &[u8] = "Extremely Large Numer Private Key".as_bytes();
@@ -103,7 +103,7 @@ impl<TSystemServices: SystemServices> Program
                         let mut hash_buffer = [0u8; Sha512::HASH_SIZE];
                         let mut hash_input_buffer = vec![0u8; Sha512::HASH_SIZE];
                         let mut hmac = hasher.build_hmac(ITERATIVE_HASHING_KEY);
-                        let mut result_buffer = BigUnsigned::with_capacity(32 / size_of::<Digit>());
+                        let mut result_buffer = BigUnsigned::with_byte_capacity(32);
                         break loop {
                             // Hash the private key's current value.
                             let byte_count = b.byte_count();

--- a/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
+++ b/bst/src/programs/console/cryptography/asymmetric/ec_private_key_fitting.rs
@@ -117,7 +117,7 @@ impl<TSystemServices: SystemServices> Program
                             }
 
                             // Increment the oversized private key.
-                            b.add_be_bytes(&[1]);
+                            b.add(&[1]);
 
                             // Take back ownership of the hash buffer.
                             hash_buffer = integer.extract_be_bytes();

--- a/bst/src/programs/console/cryptography/bip_32/child_key_derivation.rs
+++ b/bst/src/programs/console/cryptography/bip_32/child_key_derivation.rs
@@ -273,7 +273,7 @@ impl<TSystemServices: SystemServices> Program
 
         let label = match key_type {
             Bip32KeyType::Private => s16!("BIP 32 Child Private Key"),
-            Bip32KeyType::Public => todo!("BIP 32 Child Public Key"),
+            Bip32KeyType::Public => s16!("BIP 32 Child Public Key"),
         };
 
         write_string_program_output(&self.system_services, label, String16::from(&base58_key));

--- a/bst/src/programs/console/entropy/manual_collection.rs
+++ b/bst/src/programs/console/entropy/manual_collection.rs
@@ -774,10 +774,7 @@ impl<
         collector.copy_padded_bytes_to(&mut bytes);
 
         // Empty the bytes pre-emptively (they'd otherwise be zeroed on de-allocation).
-        collector
-            .extract_big_unsigned()
-            .take_data_ownership()
-            .zero();
+        collector.extract_big_unsigned().zero();
 
         // Output the raw collected bytes.
         write_bytes(&self.system_services, s16!("Collected Bytes"), &bytes);

--- a/bst/src/string16.rs
+++ b/bst/src/string16.rs
@@ -28,8 +28,8 @@ pub struct String16<'a>(&'a [u16]);
 
 impl Debug for String16<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("String16")
-            .field(&String::from_utf16(&self.content_slice()))
+        f.debug_tuple("S16")
+            .field(&String::from_utf16(&self.content_slice()).unwrap())
             .finish()
     }
 }

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -35,24 +35,6 @@ pub enum PowerAction {
     Reset,
 }
 
-#[allow(dead_code)]
-pub fn clock_cycle_count() -> u64 {
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        let mut v = 0u64;
-        core::arch::asm!("mrs {v}, cntpct_el0", v = inout(reg) v);
-        v
-    }
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        core::arch::x86_64::_rdtsc()
-    }
-    #[cfg(target_arch = "x86")]
-    unsafe {
-        core::arch::x86::_rdtsc()
-    }
-}
-
 static mut CLIPBOARD: Option<Clipboard> = None;
 
 pub trait SystemServices: Clone + 'static {
@@ -117,10 +99,6 @@ pub trait SystemServices: Clone + 'static {
 
     fn free_call_count(&self) -> usize {
         unsafe { FREE_COUNT }
-    }
-
-    fn clock_cycle_count(&self) -> u64 {
-        clock_cycle_count()
     }
 }
 

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -229,7 +229,7 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
                 RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
             };
 
-            let mut modulus_buffer = BigSigned::with_capacity(16);
+            let mut modulus_buffer = BigSigned::with_capacity(2);
             for _ in 0..iterations {
                 let (mut b1, r1) = random_big_signed(16);
                 let (b2, r2) = random_big_unsigned(15);

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 100000;
+const RANDOM_ITERATIONS: usize = 1000000;
 
 #[test]
 fn equal_big_signeds_are_equal() {

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -17,10 +17,7 @@
 use crate::{
     integers::{BigSigned, BigUnsigned},
     tests::{
-        big_integers::{
-            big_signed_to_i128, big_signed_to_u128, big_unsigned_to_u128, random_big_signed,
-            random_big_unsigned,
-        },
+        big_integers::{big_signed_to_i128, random_big_signed, random_big_unsigned},
         PARALLELIZED_TEST_THREAD_COUNT,
     },
 };
@@ -36,20 +33,20 @@ fn equal_big_signeds_are_equal() {
     let vbs = [random::<u8>(), random::<u8>(), random::<u8>()];
     let integer_sets = [
         [
-            BigSigned::from_be_bytes(false, &vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(false, &vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(false, &vec![0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(false, &vec![0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(false, &vec![vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(false, &vec![vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, vec![0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, vec![0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, vec![vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, vec![vbs[0], vbs[1], vbs[2]]),
         ],
         [
-            BigSigned::from_be_bytes(true, &vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(true, &vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(true, &vec![0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(true, &vec![0, vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(true, &vec![vbs[0], vbs[1], vbs[2]]),
-            BigSigned::from_be_bytes(true, &vec![vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, vec![0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, vec![0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, vec![vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, vec![vbs[0], vbs[1], vbs[2]]),
         ],
     ];
 
@@ -68,12 +65,12 @@ fn equal_big_signeds_are_equal() {
 fn unequal_big_signeds_are_unequal() {
     let vbs = [random::<u8>(), random::<u8>(), random::<u8>()];
     let integers = [
-        BigSigned::from_be_bytes(true, &vec![1, 1, vbs[0], vbs[1], vbs[2]]),
-        BigSigned::from_be_bytes(true, &vec![1, vbs[0], vbs[1], vbs[2]]),
-        BigSigned::from_be_bytes(true, &vec![vbs[0], vbs[1], vbs[2]]),
-        BigSigned::from_be_bytes(false, &vec![1, 1, vbs[0], vbs[1], vbs[2]]),
-        BigSigned::from_be_bytes(false, &vec![1, vbs[0], vbs[1], vbs[2]]),
-        BigSigned::from_be_bytes(false, &vec![vbs[0], vbs[1], vbs[2]]),
+        from_digits(true, vec![1, 1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(true, vec![1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(true, vec![vbs[0], vbs[1], vbs[2]]),
+        from_digits(false, vec![1, 1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(false, vec![1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(false, vec![vbs[0], vbs[1], vbs[2]]),
     ];
 
     for i in 0..integers.len() {
@@ -91,62 +88,52 @@ fn unequal_big_signeds_are_unequal() {
 #[test]
 fn big_signed_less_than() {
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 1])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![0, 0, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 1, 0])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![0, 1, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[1, 0, 0])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 0, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 1, 1])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![0, 1, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[1, 0, 1])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 0, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[1, 1, 1])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 1, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[1, 0, 0, 0])),
+        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 0, 0, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(true, &[0, 0, 1])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 1])),
+        from_digits(true, vec![0, 0, 1]).cmp(&from_digits(false, vec![0, 0, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(true, &[0, 1, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 1, 0])),
+        from_digits(true, vec![0, 1, 0]).cmp(&from_digits(false, vec![0, 1, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(true, &[1, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[1, 0, 0])),
+        from_digits(true, vec![1, 0, 0]).cmp(&from_digits(false, vec![1, 0, 0])),
         Ordering::Less
     );
 }
@@ -154,130 +141,54 @@ fn big_signed_less_than() {
 #[test]
 fn big_signed_greater_than() {
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 1])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![0, 0, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 1, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![0, 1, 0]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[1, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![1, 0, 0]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 1, 1])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![0, 1, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[1, 0, 1])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![1, 0, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[1, 1, 1])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![1, 1, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[1, 0, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(false, &[0, 0, 0])),
+        from_digits(false, vec![1, 0, 0, 0]).cmp(&from_digits(false, vec![0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 0, 1])
-            .cmp(&BigSigned::from_be_bytes(true, &[0, 0, 1])),
+        from_digits(false, vec![0, 0, 1]).cmp(&from_digits(true, vec![0, 0, 1])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[0, 1, 0])
-            .cmp(&BigSigned::from_be_bytes(true, &[0, 1, 0])),
+        from_digits(false, vec![0, 1, 0]).cmp(&from_digits(true, vec![0, 1, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        BigSigned::from_be_bytes(false, &[1, 0, 0])
-            .cmp(&BigSigned::from_be_bytes(true, &[1, 0, 0])),
+        from_digits(false, vec![1, 0, 0]).cmp(&from_digits(true, vec![1, 0, 0])),
         Ordering::Greater
     );
-}
-
-#[test]
-fn big_signed_random_and_test() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_signed(16);
-        let (b2, r2) = random_big_signed(16);
-        println!("ORD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ORR:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.and_big_signed(&b2);
-
-        assert_eq!(
-            big_signed_to_u128(&b1),
-            r1.unsigned_abs() & r2.unsigned_abs()
-        );
-        assert_eq!(b1.is_negative(), (r1 < 0) & (r2 < 0))
-    }
-}
-
-#[test]
-fn big_signed_random_xor_test() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_signed(16);
-        let (b2, r2) = random_big_signed(16);
-        println!("ORD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ORR:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.xor_big_signed(&b2);
-
-        assert_eq!(
-            big_signed_to_u128(&b1),
-            r1.unsigned_abs() ^ r2.unsigned_abs()
-        );
-        assert_eq!(b1.is_negative(), (r1 < 0) ^ (r2 < 0))
-    }
-}
-
-#[test]
-fn big_signed_random_or_test() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_signed(16);
-        let (b2, r2) = random_big_signed(16);
-        println!("ORD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ORR:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.or_big_signed(&b2);
-
-        assert_eq!(
-            big_signed_to_u128(&b1),
-            r1.unsigned_abs() | r2.unsigned_abs()
-        );
-        assert_eq!(b1.is_negative(), (r1 < 0) | (r2 < 0))
-    }
-}
-
-#[test]
-fn big_signed_random_add() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_signed(14);
-        let (b2, r2) = random_big_signed(14);
-        println!("AUG:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ADD:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.add_big_signed(&b2);
-
-        let expected_sum = r1 + r2;
-        assert_eq!(big_signed_to_i128(&b1), expected_sum);
-        assert_eq!(b1.is_negative(), expected_sum < 0);
-    }
 }
 
 #[test]
@@ -285,8 +196,6 @@ fn big_signed_random_subtract() {
     for _ in 0..RANDOM_ITERATIONS {
         let (mut b1, r1) = random_big_signed(16);
         let (b2, r2) = random_big_signed(16);
-        println!("M:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("S:{:?};{}", b2.clone_be_bytes(), r2);
         b1.subtract_big_signed(&b2);
 
         let expected_result = r1 - r2;
@@ -300,145 +209,12 @@ fn big_signed_random_multiply() {
     for _ in 0..RANDOM_ITERATIONS {
         let (mut b1, r1) = random_big_signed(8);
         let (b2, r2) = random_big_signed(8);
-        println!("MPD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("MPR:{:?};{}", b2.clone_be_bytes(), r2);
         b1.multiply_big_signed(&b2);
 
         let expected_product = r1 * r2;
         assert_eq!(big_signed_to_i128(&b1), expected_product);
         assert_eq!(b1.is_negative(), expected_product < 0);
     }
-}
-
-#[test]
-fn big_signed_random_difference() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_signed(16);
-        let (b2, r2) = random_big_signed(16);
-        println!("A:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("B:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.difference_big_signed(&b2);
-
-        assert_eq!(big_signed_to_u128(&b1), r1.abs_diff(r2));
-        assert!(!b1.is_negative());
-    }
-}
-
-#[test]
-fn big_signed_random_divide() {
-    (0..PARALLELIZED_TEST_THREAD_COUNT)
-        .into_par_iter()
-        .for_each(|i| {
-            let iterations = if i == PARALLELIZED_TEST_THREAD_COUNT - 1 {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-                    + RANDOM_ITERATIONS % PARALLELIZED_TEST_THREAD_COUNT
-            } else {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-            };
-
-            let mut remainder_buffer = BigSigned::with_capacity(16);
-            for _ in 0..iterations {
-                let (mut b1, r1) = random_big_signed(16);
-                let (b2, r2) = random_big_signed(16);
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
-                let successful_division =
-                    b1.divide_big_signed_with_remainder(&b2, &mut remainder_buffer);
-
-                if r2 == 0 {
-                    assert!(!successful_division);
-                } else {
-                    assert!(successful_division);
-                    let expected_quotient = r1 / r2;
-                    assert_eq!(big_signed_to_i128(&b1), expected_quotient);
-                    assert_eq!(b1.is_negative(), expected_quotient < 0);
-
-                    let expected_remainder = r1 % r2;
-                    assert_eq!(big_signed_to_i128(&remainder_buffer), expected_remainder);
-                    assert_eq!(remainder_buffer.is_negative(), expected_remainder < 0);
-                }
-            }
-        });
-}
-
-#[test]
-fn big_signed_random_divide_by_signed_with_modulus() {
-    (0..PARALLELIZED_TEST_THREAD_COUNT)
-        .into_par_iter()
-        .for_each(|i| {
-            let iterations = if i == PARALLELIZED_TEST_THREAD_COUNT - 1 {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-                    + RANDOM_ITERATIONS % PARALLELIZED_TEST_THREAD_COUNT
-            } else {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-            };
-
-            let mut modulus_buffer = BigSigned::with_capacity(16);
-            for _ in 0..iterations {
-                let (mut b1, r1) = random_big_signed(16);
-                let (b2, r2) = random_big_signed(16);
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
-                let successful_division =
-                    b1.divide_big_signed_with_modulus(&b2, &mut modulus_buffer);
-                if r2 == 0 {
-                    assert!(!successful_division);
-                } else {
-                    assert!(successful_division);
-                    let expected_quotient = r1 / r2;
-                    assert_eq!(big_signed_to_i128(&b1), expected_quotient);
-                    assert_eq!(b1.is_negative(), expected_quotient < 0);
-
-                    let expected_modulus = ((r1 % r2) + r2) % r2;
-                    assert_eq!(big_signed_to_i128(&modulus_buffer), expected_modulus);
-                    assert_eq!(modulus_buffer.is_negative(), expected_modulus < 0);
-                }
-            }
-        });
-}
-
-#[test]
-fn big_signed_random_divide_by_unsigned_with_unsigned_modulus() {
-    (0..PARALLELIZED_TEST_THREAD_COUNT)
-        .into_par_iter()
-        .for_each(|i| {
-            let iterations = if i == PARALLELIZED_TEST_THREAD_COUNT - 1 {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-                    + RANDOM_ITERATIONS % PARALLELIZED_TEST_THREAD_COUNT
-            } else {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-            };
-
-            let mut modulus_buffer = BigUnsigned::with_capacity(16);
-            for _ in 0..iterations {
-                let (mut b1, r1) = random_big_signed(16);
-                let (b2, r2) = random_big_unsigned(15);
-                let r2i = r2 as i128;
-
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
-                let successful_division =
-                    b1.divide_big_unsigned_with_modulus(&b2, &mut modulus_buffer);
-                if r2 == 0 {
-                    assert!(!successful_division);
-                } else {
-                    assert!(successful_division);
-                    let expected_quotient = r1 / r2i;
-                    assert_eq!(big_signed_to_i128(&b1), expected_quotient);
-                    assert_eq!(b1.is_negative(), expected_quotient < 0);
-
-                    let expected_modulus = ((r1 % r2i) + r2i) % r2i;
-                    assert_eq!(
-                        big_unsigned_to_u128(&modulus_buffer) as i128,
-                        expected_modulus
-                    );
-                    assert!(expected_modulus >= 0);
-                }
-            }
-        });
 }
 
 #[test]
@@ -459,9 +235,6 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
                 let (b2, r2) = random_big_unsigned(15);
                 let r2i = r2 as i128;
 
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
                 let successful_division =
                     b1.divide_big_unsigned_with_signed_modulus(&b2, &mut modulus_buffer);
                 if r2 == 0 {
@@ -480,33 +253,6 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
         });
 }
 
-#[test]
-fn big_signed_random_modulo() {
-    (0..PARALLELIZED_TEST_THREAD_COUNT)
-        .into_par_iter()
-        .for_each(|i| {
-            let iterations = if i == PARALLELIZED_TEST_THREAD_COUNT - 1 {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-                    + RANDOM_ITERATIONS % PARALLELIZED_TEST_THREAD_COUNT
-            } else {
-                RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
-            };
-
-            for _ in 0..iterations {
-                let (mut b1, r1) = random_big_signed(16);
-                let (b2, r2) = random_big_signed(16);
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
-                let success = b1.modulo_big_signed(&b2);
-                if r2 == 0 {
-                    assert!(!success);
-                } else {
-                    assert!(success);
-                    let expected_modulus = ((r1 % r2) + r2) % r2;
-                    assert_eq!(big_signed_to_i128(&b1), expected_modulus);
-                    assert_eq!(b1.is_negative(), expected_modulus < 0);
-                }
-            }
-        });
+fn from_digits(is_negative: bool, digits: Vec<u8>) -> BigSigned {
+    BigSigned::from_unsigned(is_negative, BigUnsigned::from_vec(digits))
 }

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 1000;
+const RANDOM_ITERATIONS: usize = 10000;
 
 #[test]
 fn equal_big_signeds_are_equal() {

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    integers::{BigSigned, BigUnsigned},
+    integers::{BigSigned, BigUnsigned, Digit},
     tests::{
         big_integers::{big_signed_to_i128, random_big_signed, random_big_unsigned},
         PARALLELIZED_TEST_THREAD_COUNT,
@@ -26,11 +26,11 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 100000;
+const RANDOM_ITERATIONS: usize = 1000;
 
 #[test]
 fn equal_big_signeds_are_equal() {
-    let vbs = [random::<u64>(), random::<u64>(), random::<u64>()];
+    let vbs = [random::<Digit>(), random::<Digit>(), random::<Digit>()];
     let integer_sets = [
         [
             from_digits(false, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
@@ -63,7 +63,7 @@ fn equal_big_signeds_are_equal() {
 
 #[test]
 fn unequal_big_signeds_are_unequal() {
-    let vbs = [random::<u64>(), random::<u64>(), random::<u64>()];
+    let vbs = [random::<Digit>(), random::<Digit>(), random::<Digit>()];
     let integers = [
         from_digits(true, vec![1, 1, vbs[0], vbs[1], vbs[2]]),
         from_digits(true, vec![1, vbs[0], vbs[1], vbs[2]]),
@@ -253,6 +253,6 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
         });
 }
 
-fn from_digits(is_negative: bool, digits: Vec<u64>) -> BigSigned {
+fn from_digits(is_negative: bool, digits: Vec<Digit>) -> BigSigned {
     BigSigned::from_unsigned(is_negative, BigUnsigned::from_vec(digits))
 }

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -30,7 +30,7 @@ const RANDOM_ITERATIONS: usize = 100000;
 
 #[test]
 fn equal_big_signeds_are_equal() {
-    let vbs = [random::<u8>(), random::<u8>(), random::<u8>()];
+    let vbs = [random::<u64>(), random::<u64>(), random::<u64>()];
     let integer_sets = [
         [
             from_digits(false, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
@@ -63,7 +63,7 @@ fn equal_big_signeds_are_equal() {
 
 #[test]
 fn unequal_big_signeds_are_unequal() {
-    let vbs = [random::<u8>(), random::<u8>(), random::<u8>()];
+    let vbs = [random::<u64>(), random::<u64>(), random::<u64>()];
     let integers = [
         from_digits(true, vec![1, 1, vbs[0], vbs[1], vbs[2]]),
         from_digits(true, vec![1, vbs[0], vbs[1], vbs[2]]),
@@ -253,6 +253,6 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
         });
 }
 
-fn from_digits(is_negative: bool, digits: Vec<u8>) -> BigSigned {
+fn from_digits(is_negative: bool, digits: Vec<u64>) -> BigSigned {
     BigSigned::from_unsigned(is_negative, BigUnsigned::from_vec(digits))
 }

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -21,7 +21,6 @@ use crate::{
         PARALLELIZED_TEST_THREAD_COUNT,
     },
 };
-use alloc::vec;
 use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
@@ -33,20 +32,20 @@ fn equal_big_signeds_are_equal() {
     let vbs = [random::<Digit>(), random::<Digit>(), random::<Digit>()];
     let integer_sets = [
         [
-            from_digits(false, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(false, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(false, vec![0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(false, vec![0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(false, vec![vbs[0], vbs[1], vbs[2]]),
-            from_digits(false, vec![vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, &[0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, &[0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, &[0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, &[0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, &[vbs[0], vbs[1], vbs[2]]),
+            from_digits(false, &[vbs[0], vbs[1], vbs[2]]),
         ],
         [
-            from_digits(true, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(true, vec![0, 0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(true, vec![0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(true, vec![0, vbs[0], vbs[1], vbs[2]]),
-            from_digits(true, vec![vbs[0], vbs[1], vbs[2]]),
-            from_digits(true, vec![vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, &[0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, &[0, 0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, &[0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, &[0, vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, &[vbs[0], vbs[1], vbs[2]]),
+            from_digits(true, &[vbs[0], vbs[1], vbs[2]]),
         ],
     ];
 
@@ -65,12 +64,12 @@ fn equal_big_signeds_are_equal() {
 fn unequal_big_signeds_are_unequal() {
     let vbs = [random::<Digit>(), random::<Digit>(), random::<Digit>()];
     let integers = [
-        from_digits(true, vec![1, 1, vbs[0], vbs[1], vbs[2]]),
-        from_digits(true, vec![1, vbs[0], vbs[1], vbs[2]]),
-        from_digits(true, vec![vbs[0], vbs[1], vbs[2]]),
-        from_digits(false, vec![1, 1, vbs[0], vbs[1], vbs[2]]),
-        from_digits(false, vec![1, vbs[0], vbs[1], vbs[2]]),
-        from_digits(false, vec![vbs[0], vbs[1], vbs[2]]),
+        from_digits(true, &[1, 1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(true, &[1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(true, &[vbs[0], vbs[1], vbs[2]]),
+        from_digits(false, &[1, 1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(false, &[1, vbs[0], vbs[1], vbs[2]]),
+        from_digits(false, &[vbs[0], vbs[1], vbs[2]]),
     ];
 
     for i in 0..integers.len() {
@@ -88,52 +87,52 @@ fn unequal_big_signeds_are_unequal() {
 #[test]
 fn big_signed_less_than() {
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![0, 0, 1])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[0, 0, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![0, 1, 0])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[0, 1, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 0, 0])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[1, 0, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![0, 1, 1])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[0, 1, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 0, 1])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[1, 0, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 1, 1])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[1, 1, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 0]).cmp(&from_digits(false, vec![1, 0, 0, 0])),
+        from_digits(false, &[0, 0, 0]).cmp(&from_digits(false, &[1, 0, 0, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(true, vec![0, 0, 1]).cmp(&from_digits(false, vec![0, 0, 1])),
+        from_digits(true, &[0, 0, 1]).cmp(&from_digits(false, &[0, 0, 1])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(true, vec![0, 1, 0]).cmp(&from_digits(false, vec![0, 1, 0])),
+        from_digits(true, &[0, 1, 0]).cmp(&from_digits(false, &[0, 1, 0])),
         Ordering::Less
     );
 
     assert_eq!(
-        from_digits(true, vec![1, 0, 0]).cmp(&from_digits(false, vec![1, 0, 0])),
+        from_digits(true, &[1, 0, 0]).cmp(&from_digits(false, &[1, 0, 0])),
         Ordering::Less
     );
 }
@@ -141,52 +140,52 @@ fn big_signed_less_than() {
 #[test]
 fn big_signed_greater_than() {
     assert_eq!(
-        from_digits(false, vec![0, 0, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[0, 0, 1]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 1, 0]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[0, 1, 0]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![1, 0, 0]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[1, 0, 0]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 1, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[0, 1, 1]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![1, 0, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[1, 0, 1]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![1, 1, 1]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[1, 1, 1]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![1, 0, 0, 0]).cmp(&from_digits(false, vec![0, 0, 0])),
+        from_digits(false, &[1, 0, 0, 0]).cmp(&from_digits(false, &[0, 0, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 0, 1]).cmp(&from_digits(true, vec![0, 0, 1])),
+        from_digits(false, &[0, 0, 1]).cmp(&from_digits(true, &[0, 0, 1])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![0, 1, 0]).cmp(&from_digits(true, vec![0, 1, 0])),
+        from_digits(false, &[0, 1, 0]).cmp(&from_digits(true, &[0, 1, 0])),
         Ordering::Greater
     );
 
     assert_eq!(
-        from_digits(false, vec![1, 0, 0]).cmp(&from_digits(true, vec![1, 0, 0])),
+        from_digits(false, &[1, 0, 0]).cmp(&from_digits(true, &[1, 0, 0])),
         Ordering::Greater
     );
 }
@@ -253,6 +252,6 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
         });
 }
 
-fn from_digits(is_negative: bool, digits: Vec<Digit>) -> BigSigned {
-    BigSigned::from_unsigned(is_negative, BigUnsigned::from_vec(digits))
+fn from_digits(is_negative: bool, digits: &[Digit]) -> BigSigned {
+    BigSigned::from_unsigned(is_negative, BigUnsigned::from_digits(digits))
 }

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 10000;
+const RANDOM_ITERATIONS: usize = 100000;
 
 #[test]
 fn equal_big_signeds_are_equal() {

--- a/bst/src/tests/big_integers/big_signed_integers.rs
+++ b/bst/src/tests/big_integers/big_signed_integers.rs
@@ -21,7 +21,7 @@ use crate::{
         PARALLELIZED_TEST_THREAD_COUNT,
     },
 };
-use core::cmp::Ordering;
+use core::{cmp::Ordering, mem::size_of};
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
@@ -228,7 +228,7 @@ fn big_signed_random_divide_by_unsigned_with_signed_modulus() {
                 RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
             };
 
-            let mut modulus_buffer = BigSigned::with_capacity(2);
+            let mut modulus_buffer = BigSigned::with_byte_capacity(size_of::<u128>());
             for _ in 0..iterations {
                 let (mut b1, r1) = random_big_signed(16);
                 let (b2, r2) = random_big_unsigned(15);

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 use alloc::vec;
-use core::cmp::Ordering;
+use core::{cmp::Ordering, mem::size_of};
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
@@ -180,7 +180,7 @@ fn big_unsigned_random_multiply() {
 
 #[test]
 fn big_unsigned_edge_case_divide() {
-    let mut remainder_buffer = BigUnsigned::with_capacity(2);
+    let mut remainder_buffer = BigUnsigned::with_byte_capacity(size_of::<u128>());
 
     let mut b1 = BigUnsigned::from_be_bytes(&[53, 224, 51, 154, 252]);
     let b2 = BigUnsigned::from_be_bytes(&[53, 224]);
@@ -249,7 +249,7 @@ fn big_unsigned_random_divide() {
                 RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
             };
 
-            let mut remainder_buffer = BigUnsigned::with_capacity(2);
+            let mut remainder_buffer = BigUnsigned::with_byte_capacity(size_of::<u128>());
             for _ in 0..iterations {
                 let (mut b1, r1) = random_big_unsigned(16);
                 let (b2, r2) = random_big_unsigned(16);

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -42,7 +42,6 @@ fn equal_big_unsigneds_are_equal() {
 
     for i in 0..integers.len() {
         for j in 0..integers.len() {
-            // println!("{}, {}", i, j);
             assert_eq!(integers[i], integers[j]);
             assert_eq!(integers[i].cmp(&integers[j]), Ordering::Equal);
         }
@@ -64,7 +63,6 @@ fn unequal_big_unsigneds_are_unequal() {
                 continue;
             }
 
-            // println!("{}, {}", i, j);
             assert_ne!(integers[i], integers[j]);
             assert_ne!(integers[i].cmp(&integers[j]), Ordering::Equal);
         }

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -182,7 +182,7 @@ fn big_unsigned_random_multiply() {
 
 #[test]
 fn big_unsigned_edge_case_divide() {
-    let mut remainder_buffer = BigUnsigned::with_capacity(16);
+    let mut remainder_buffer = BigUnsigned::with_capacity(2);
 
     let mut b1 = BigUnsigned::from_be_bytes(&[53, 224, 51, 154, 252]);
     let b2 = BigUnsigned::from_be_bytes(&[53, 224]);
@@ -251,7 +251,7 @@ fn big_unsigned_random_divide() {
                 RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
             };
 
-            let mut remainder_buffer = BigUnsigned::with_capacity(16);
+            let mut remainder_buffer = BigUnsigned::with_capacity(2);
             for _ in 0..iterations {
                 let (mut b1, r1) = random_big_unsigned(16);
                 let (b2, r2) = random_big_unsigned(16);

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 100000;
+const RANDOM_ITERATIONS: usize = 1000;
 
 #[test]
 fn equal_big_unsigneds_are_equal() {

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -148,51 +148,10 @@ fn big_unsigned_greater_than() {
 }
 
 #[test]
-fn big_unsigned_random_and_test() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_unsigned(16);
-        let (b2, r2) = random_big_unsigned(16);
-        println!("ORD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ORR:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.and_big_unsigned(&b2);
-
-        assert_eq!(big_unsigned_to_u128(&b1), r1 & r2);
-    }
-}
-
-#[test]
-fn big_unsigned_random_xor_test() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_unsigned(16);
-        let (b2, r2) = random_big_unsigned(16);
-        println!("ORD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ORR:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.xor_big_unsigned(&b2);
-
-        assert_eq!(big_unsigned_to_u128(&b1), r1 ^ r2);
-    }
-}
-
-#[test]
-fn big_unsigned_random_or_test() {
-    for _ in 0..RANDOM_ITERATIONS {
-        let (mut b1, r1) = random_big_unsigned(16);
-        let (b2, r2) = random_big_unsigned(16);
-        println!("ORD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ORR:{:?};{}", b2.clone_be_bytes(), r2);
-        b1.or_big_unsigned(&b2);
-
-        assert_eq!(big_unsigned_to_u128(&b1), r1 | r2);
-    }
-}
-
-#[test]
 fn big_unsigned_random_add() {
     for _ in 0..RANDOM_ITERATIONS {
         let (mut b1, r1) = random_big_unsigned(15);
         let (b2, r2) = random_big_unsigned(15);
-        println!("AUG:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("ADD:{:?};{}", b2.clone_be_bytes(), r2);
         b1.add_big_unsigned(&b2);
 
         assert_eq!(big_unsigned_to_u128(&b1), r1 + r2);
@@ -204,8 +163,6 @@ fn big_unsigned_random_subtract() {
     for _ in 0..RANDOM_ITERATIONS {
         let (mut b1, r1) = random_big_unsigned(16);
         let (b2, r2) = random_big_unsigned(16);
-        println!("M:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("S:{:?};{}", b2.clone_be_bytes(), r2);
         b1.subtract_big_unsigned(&b2);
 
         assert_eq!(big_unsigned_to_u128(&b1), if r1 > r2 { r1 - r2 } else { 0 });
@@ -217,8 +174,6 @@ fn big_unsigned_random_multiply() {
     for _ in 0..RANDOM_ITERATIONS {
         let (mut b1, r1) = random_big_unsigned(8);
         let (b2, r2) = random_big_unsigned(8);
-        println!("MPD:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("MPR:{:?};{}", b2.clone_be_bytes(), r2);
         b1.multiply_big_unsigned(&b2);
 
         assert_eq!(big_unsigned_to_u128(&b1), r1 * r2);
@@ -300,9 +255,6 @@ fn big_unsigned_random_divide() {
             for _ in 0..iterations {
                 let (mut b1, r1) = random_big_unsigned(16);
                 let (b2, r2) = random_big_unsigned(16);
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
                 let successful_division =
                     b1.divide_big_unsigned_with_remainder(&b2, &mut remainder_buffer);
 
@@ -332,9 +284,6 @@ fn big_unsigned_random_modulo() {
             for _ in 0..iterations {
                 let (mut b1, r1) = random_big_unsigned(16);
                 let (b2, r2) = random_big_unsigned(16);
-                println!("DND:{:?};{}", b1.clone_be_bytes(), r1);
-                println!("DSR:{:?};{}", b2.clone_be_bytes(), r2);
-
                 let success = b1.modulo_big_unsigned(&b2);
                 if r2 == 0 {
                     assert!(!success);
@@ -351,8 +300,6 @@ fn big_unsigned_random_difference() {
     for _ in 0..RANDOM_ITERATIONS {
         let (mut b1, r1) = random_big_unsigned(16);
         let (b2, r2) = random_big_unsigned(16);
-        println!("A:{:?};{}", b1.clone_be_bytes(), r1);
-        println!("B:{:?};{}", b2.clone_be_bytes(), r2);
         b1.difference_big_unsigned(&b2);
 
         assert_eq!(big_unsigned_to_u128(&b1), r1.abs_diff(r2));

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 10000;
+const RANDOM_ITERATIONS: usize = 100000;
 
 #[test]
 fn equal_big_unsigneds_are_equal() {

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 100000;
+const RANDOM_ITERATIONS: usize = 1000000;
 
 #[test]
 fn equal_big_unsigneds_are_equal() {

--- a/bst/src/tests/big_integers/big_unsigned_integers.rs
+++ b/bst/src/tests/big_integers/big_unsigned_integers.rs
@@ -26,7 +26,7 @@ use core::cmp::Ordering;
 use rand::random;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 1000;
+const RANDOM_ITERATIONS: usize = 10000;
 
 #[test]
 fn equal_big_unsigneds_are_equal() {

--- a/bst/src/tests/big_integers/mod.rs
+++ b/bst/src/tests/big_integers/mod.rs
@@ -18,6 +18,7 @@ mod big_signed_integers;
 mod big_unsigned_integers;
 
 use crate::integers::{BigSigned, BigUnsigned, BITS_PER_DIGIT};
+use core::mem::size_of;
 use rand::{random, thread_rng, Rng};
 
 fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
@@ -29,7 +30,7 @@ fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
         panic!("Tried to read a BigUnsigned with more than 128 bits into a u128");
     }
 
-    let mut bytes = [0u8; 16];
+    let mut bytes = [0u8; size_of::<u128>()];
     big_unsigned.copy_be_bytes_to(&mut bytes);
     u128::from_be_bytes(bytes)
 }
@@ -56,14 +57,14 @@ fn i128_to_big_signed(value: i128) -> BigSigned {
 }
 
 fn bytes_to_u128(bytes: &[u8]) -> u128 {
-    let mut u128_buffer = [0u8; 16];
-    u128_buffer[16 - bytes.len()..].copy_from_slice(&bytes);
+    let mut u128_buffer = [0u8; size_of::<u128>()];
+    u128_buffer[size_of::<u128>() - bytes.len()..].copy_from_slice(&bytes);
     u128::from_be_bytes(u128_buffer)
 }
 
 fn bytes_to_i128(bytes: &[u8]) -> i128 {
-    let mut i128_buffer = [0u8; 16];
-    i128_buffer[16 - bytes.len()..].copy_from_slice(&bytes);
+    let mut i128_buffer = [0u8; size_of::<u128>()];
+    i128_buffer[size_of::<u128>() - bytes.len()..].copy_from_slice(&bytes);
     i128::from_be_bytes(i128_buffer)
 }
 

--- a/bst/src/tests/big_integers/mod.rs
+++ b/bst/src/tests/big_integers/mod.rs
@@ -17,7 +17,7 @@
 mod big_signed_integers;
 mod big_unsigned_integers;
 
-use crate::integers::{BigSigned, BigUnsigned, DIGIT_SHIFT};
+use crate::integers::{BigSigned, BigUnsigned, BITS_PER_DIGIT};
 use rand::{random, thread_rng, Rng};
 
 fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
@@ -25,7 +25,7 @@ fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
         return 0;
     }
 
-    if big_unsigned.digit_count() * DIGIT_SHIFT > 128 {
+    if big_unsigned.digit_count() * BITS_PER_DIGIT > 128 {
         panic!("Tried to read a BigUnsigned with more than 128 bits into a u128");
     }
 

--- a/bst/src/tests/big_integers/mod.rs
+++ b/bst/src/tests/big_integers/mod.rs
@@ -21,7 +21,7 @@ use crate::integers::{BigSigned, BigUnsigned};
 use rand::{random, thread_rng, Rng};
 
 fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
-    let bytes = big_unsigned.clone_be_bytes();
+    let bytes = big_unsigned.borrow_digits();
     let bytes = match bytes.iter().enumerate().find(|(_, x)| **x != 0) {
         Some((i, _)) => &bytes[i..],
         None => return 0,
@@ -33,7 +33,7 @@ fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
 }
 
 fn big_signed_to_i128(big_signed: &BigSigned) -> i128 {
-    let bytes = big_signed.clone_be_bytes();
+    let bytes = big_signed.borrow_unsigned().borrow_digits();
     let bytes = match bytes.iter().enumerate().find(|(_, x)| **x != 0) {
         Some((i, _)) => &bytes[i..],
         None => return 0,
@@ -49,20 +49,11 @@ fn big_signed_to_i128(big_signed: &BigSigned) -> i128 {
     }
 }
 
-fn big_signed_to_u128(big_unsigned: &BigSigned) -> u128 {
-    let bytes = big_unsigned.clone_be_bytes();
-    let bytes = match bytes.iter().enumerate().find(|(_, x)| **x != 0) {
-        Some((i, _)) => &bytes[i..],
-        None => return 0,
-    };
-
-    let mut u128_buffer = [0u8; 16];
-    u128_buffer[16 - bytes.len()..].copy_from_slice(&bytes);
-    u128::from_be_bytes(u128_buffer)
-}
-
 fn i128_to_big_signed(value: i128) -> BigSigned {
-    BigSigned::from_be_bytes(value < 0, &value.unsigned_abs().to_be_bytes())
+    BigSigned::from_unsigned(
+        value < 0,
+        BigUnsigned::from_be_bytes(&value.unsigned_abs().to_be_bytes()),
+    )
 }
 
 fn bytes_to_u128(bytes: &[u8]) -> u128 {

--- a/bst/src/tests/big_integers/mod.rs
+++ b/bst/src/tests/big_integers/mod.rs
@@ -31,7 +31,7 @@ fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
     }
 
     let mut bytes = [0u8; size_of::<u128>()];
-    big_unsigned.copy_be_bytes_to(&mut bytes);
+    assert!(big_unsigned.try_copy_be_bytes_to(&mut bytes));
     u128::from_be_bytes(bytes)
 }
 

--- a/bst/src/tests/big_integers/mod.rs
+++ b/bst/src/tests/big_integers/mod.rs
@@ -29,14 +29,9 @@ fn big_unsigned_to_u128(big_unsigned: &BigUnsigned) -> u128 {
         panic!("Tried to read a BigUnsigned with more than 128 bits into a u128");
     }
 
-    let mut aggregate = 0u128;
-    let digits = big_unsigned.borrow_digits();
-    for i in (0..digits.len()).rev() {
-        aggregate <<= DIGIT_SHIFT;
-        aggregate |= digits[i] as u128;
-    }
-
-    aggregate
+    let mut bytes = [0u8; 16];
+    big_unsigned.copy_be_bytes_to(&mut bytes);
+    u128::from_be_bytes(bytes)
 }
 
 fn big_signed_to_i128(big_signed: &BigSigned) -> i128 {

--- a/bst/src/tests/cryptography/asymmetric/point_operations.rs
+++ b/bst/src/tests/cryptography/asymmetric/point_operations.rs
@@ -45,7 +45,7 @@ fn point_addition_1() {
     let p5 = point(993, 1231);
 
     // Infinity
-    let inf = EllipticCurvePoint::infinity(1);
+    let inf = EllipticCurvePoint::infinity(4);
     let mut p = inf.clone();
 
     // Inf + Inf = Inf
@@ -214,7 +214,7 @@ fn point_addition_2() {
     let p5 = point(56, 8);
 
     // Infinity
-    let inf = EllipticCurvePoint::infinity(1);
+    let inf = EllipticCurvePoint::infinity(2);
     let mut p = inf.clone();
 
     // Inf + Inf = Inf
@@ -375,7 +375,7 @@ fn point_addition_2() {
 #[test]
 fn point_doubling_1() {
     let mut context = point_addition_context_1();
-    let mut p = EllipticCurvePoint::infinity(1);
+    let mut p = EllipticCurvePoint::infinity(4);
 
     // (22, 2321) + (22, 2321) = (605, 851)
     p = double(p, &point(22, 2321), &mut context);
@@ -401,7 +401,7 @@ fn point_doubling_1() {
 #[test]
 fn point_doubling_2() {
     let mut context = point_addition_context_2();
-    let mut p = EllipticCurvePoint::infinity(1);
+    let mut p = EllipticCurvePoint::infinity(2);
 
     // (17, 10) + (17, 10) = (32, 90)
     p = double(p, &point(17, 10), &mut context);
@@ -425,11 +425,11 @@ fn point_doubling_2() {
 }
 
 fn point_addition_context_1() -> EllipticCurvePointAdditionContext {
-    EllipticCurvePointAdditionContext::from(p1(), a1(), 1)
+    EllipticCurvePointAdditionContext::from(4, p1(), a1())
 }
 
 fn point_addition_context_2() -> EllipticCurvePointAdditionContext {
-    EllipticCurvePointAdditionContext::from(p2(), a2(), 1)
+    EllipticCurvePointAdditionContext::from(2, p2(), a2())
 }
 
 fn p1() -> &'static BigUnsigned {
@@ -449,7 +449,7 @@ fn a2() -> &'static BigUnsigned {
 }
 
 fn point(x: u16, y: u16) -> EllipticCurvePoint {
-    let mut p = EllipticCurvePoint::infinity(1);
+    let mut p = EllipticCurvePoint::infinity(4);
     let (xp, yp) = p.borrow_coordinates_mut();
     xp.copy_be_bytes_from(&x.to_be_bytes(), false);
     yp.copy_be_bytes_from(&y.to_be_bytes(), false);

--- a/bst/src/tests/cryptography/asymmetric/point_operations.rs
+++ b/bst/src/tests/cryptography/asymmetric/point_operations.rs
@@ -17,7 +17,7 @@
 use crate::{
     cryptography::asymmetric::ecc::{EllipticCurvePoint, EllipticCurvePointAdditionContext},
     global_runtime_immutable::GlobalRuntimeImmutable,
-    integers::{BigSigned, BigUnsigned},
+    integers::BigUnsigned,
 };
 
 static mut P1: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
@@ -449,10 +449,15 @@ fn a2() -> &'static BigUnsigned {
 }
 
 fn point(x: u16, y: u16) -> EllipticCurvePoint {
-    EllipticCurvePoint::from(
-        BigSigned::from_unsigned(false, BigUnsigned::from_be_bytes(&x.to_be_bytes())),
-        BigSigned::from_unsigned(false, BigUnsigned::from_be_bytes(&y.to_be_bytes())),
-    )
+    let mut p = EllipticCurvePoint::infinity(4);
+    let (xp, yp) = p.borrow_coordinates_mut();
+    xp.borrow_unsigned_mut().copy_digits_from(&x.to_be_bytes());
+    yp.borrow_unsigned_mut().copy_digits_from(&y.to_be_bytes());
+    unsafe {
+        p.set_not_infinity();
+    }
+
+    p
 }
 
 fn add(

--- a/bst/src/tests/cryptography/asymmetric/point_operations.rs
+++ b/bst/src/tests/cryptography/asymmetric/point_operations.rs
@@ -17,7 +17,7 @@
 use crate::{
     cryptography::asymmetric::ecc::{EllipticCurvePoint, EllipticCurvePointAdditionContext},
     global_runtime_immutable::GlobalRuntimeImmutable,
-    integers::BigUnsigned,
+    integers::{BigUnsigned, Digit},
 };
 
 static mut P1: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
@@ -451,8 +451,8 @@ fn a2() -> &'static BigUnsigned {
 fn point(x: u16, y: u16) -> EllipticCurvePoint {
     let mut p = EllipticCurvePoint::infinity(1);
     let (xp, yp) = p.borrow_coordinates_mut();
-    xp.copy_digits_from(&[x as u64], false);
-    yp.copy_digits_from(&[y as u64], false);
+    xp.copy_digits_from(&[x as Digit], false);
+    yp.copy_digits_from(&[y as Digit], false);
     unsafe {
         p.set_not_infinity();
     }

--- a/bst/src/tests/cryptography/asymmetric/point_operations.rs
+++ b/bst/src/tests/cryptography/asymmetric/point_operations.rs
@@ -45,7 +45,7 @@ fn point_addition_1() {
     let p5 = point(993, 1231);
 
     // Infinity
-    let inf = EllipticCurvePoint::infinity(4);
+    let inf = EllipticCurvePoint::infinity(1);
     let mut p = inf.clone();
 
     // Inf + Inf = Inf
@@ -214,7 +214,7 @@ fn point_addition_2() {
     let p5 = point(56, 8);
 
     // Infinity
-    let inf = EllipticCurvePoint::infinity(2);
+    let inf = EllipticCurvePoint::infinity(1);
     let mut p = inf.clone();
 
     // Inf + Inf = Inf
@@ -375,7 +375,7 @@ fn point_addition_2() {
 #[test]
 fn point_doubling_1() {
     let mut context = point_addition_context_1();
-    let mut p = EllipticCurvePoint::infinity(4);
+    let mut p = EllipticCurvePoint::infinity(1);
 
     // (22, 2321) + (22, 2321) = (605, 851)
     p = double(p, &point(22, 2321), &mut context);
@@ -401,7 +401,7 @@ fn point_doubling_1() {
 #[test]
 fn point_doubling_2() {
     let mut context = point_addition_context_2();
-    let mut p = EllipticCurvePoint::infinity(2);
+    let mut p = EllipticCurvePoint::infinity(1);
 
     // (17, 10) + (17, 10) = (32, 90)
     p = double(p, &point(17, 10), &mut context);
@@ -425,11 +425,11 @@ fn point_doubling_2() {
 }
 
 fn point_addition_context_1() -> EllipticCurvePointAdditionContext {
-    EllipticCurvePointAdditionContext::from(p1(), a1(), 4)
+    EllipticCurvePointAdditionContext::from(p1(), a1(), 1)
 }
 
 fn point_addition_context_2() -> EllipticCurvePointAdditionContext {
-    EllipticCurvePointAdditionContext::from(p2(), a2(), 2)
+    EllipticCurvePointAdditionContext::from(p2(), a2(), 1)
 }
 
 fn p1() -> &'static BigUnsigned {
@@ -449,7 +449,7 @@ fn a2() -> &'static BigUnsigned {
 }
 
 fn point(x: u16, y: u16) -> EllipticCurvePoint {
-    let mut p = EllipticCurvePoint::infinity(4);
+    let mut p = EllipticCurvePoint::infinity(1);
     let (xp, yp) = p.borrow_coordinates_mut();
     xp.copy_digits_from(&[x as u64], false);
     yp.copy_digits_from(&[y as u64], false);

--- a/bst/src/tests/cryptography/asymmetric/point_operations.rs
+++ b/bst/src/tests/cryptography/asymmetric/point_operations.rs
@@ -451,8 +451,8 @@ fn a2() -> &'static BigUnsigned {
 fn point(x: u16, y: u16) -> EllipticCurvePoint {
     let mut p = EllipticCurvePoint::infinity(4);
     let (xp, yp) = p.borrow_coordinates_mut();
-    xp.borrow_unsigned_mut().copy_digits_from(&x.to_be_bytes());
-    yp.borrow_unsigned_mut().copy_digits_from(&y.to_be_bytes());
+    xp.copy_digits_from(&[x as u64], false);
+    yp.copy_digits_from(&[y as u64], false);
     unsafe {
         p.set_not_infinity();
     }

--- a/bst/src/tests/cryptography/asymmetric/point_operations.rs
+++ b/bst/src/tests/cryptography/asymmetric/point_operations.rs
@@ -17,7 +17,7 @@
 use crate::{
     cryptography::asymmetric::ecc::{EllipticCurvePoint, EllipticCurvePointAdditionContext},
     global_runtime_immutable::GlobalRuntimeImmutable,
-    integers::{BigUnsigned, Digit},
+    integers::BigUnsigned,
 };
 
 static mut P1: GlobalRuntimeImmutable<BigUnsigned, fn() -> BigUnsigned> =
@@ -451,8 +451,8 @@ fn a2() -> &'static BigUnsigned {
 fn point(x: u16, y: u16) -> EllipticCurvePoint {
     let mut p = EllipticCurvePoint::infinity(1);
     let (xp, yp) = p.borrow_coordinates_mut();
-    xp.copy_digits_from(&[x as Digit], false);
-    yp.copy_digits_from(&[y as Digit], false);
+    xp.copy_be_bytes_from(&x.to_be_bytes(), false);
+    yp.copy_be_bytes_from(&y.to_be_bytes(), false);
     unsafe {
         p.set_not_infinity();
     }

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -103,7 +103,7 @@ fn secp256k1_derive_pubkey_random_privkey() {
         let secp_context = secp256k1::Secp256k1::new();
         let mut padded_private_key = [0u8; 32];
 
-        for j in 0..iterations {
+        for _ in 0..iterations {
             let private_key = BigUnsigned::from_be_bytes(
                 &(0..thread_rng().gen_range(1..33))
                     .into_iter()
@@ -126,13 +126,8 @@ fn secp256k1_derive_pubkey_random_privkey() {
                             .public_key(&secp_context)
                             .serialize();
 
-                    println!("{},{}P: {:?}", i, j, p);
-
                     expected_decompressed_y_buffer.set_equal_to(&p.borrow_coordinates().1.borrow_unsigned());
                     let actual_serialized_key_bytes = crate::cryptography::asymmetric::ecc::secp256k1::serialized_public_key_bytes(p).unwrap();
-
-                    println!("{},{}E: {:?}", i, j, expected_serialized_key_bytes);
-                    println!("{},{}A: {:?}", i, j, actual_serialized_key_bytes);
 
                     // Assert public key is as expected.
                     assert_eq!(
@@ -153,12 +148,9 @@ fn secp256k1_derive_pubkey_random_privkey() {
                         )
                 }
                 None => {
-                    println!("{},{}: None", i, j);
                     assert!(private_key.is_zero() || private_key.cmp(crate::cryptography::asymmetric::ecc::secp256k1::n()) != Ordering::Less);
                 }
             };
-
-            println!("{},{} complete.", i, j);
         }
     });
 }

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -95,9 +95,9 @@ fn secp256k1_derive_pubkey_random_privkey() {
             RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
         };
 
-        let mut decompression_buffer_x = BigUnsigned::with_capacity(32);
-        let mut decompression_buffer_y = BigUnsigned::with_capacity(32);
-        let mut expected_decompressed_y_buffer = BigUnsigned::with_capacity(32);
+        let mut decompression_buffer_x = BigUnsigned::with_capacity(2);
+        let mut decompression_buffer_y = BigUnsigned::with_capacity(2);
+        let mut expected_decompressed_y_buffer = BigUnsigned::with_capacity(2);
         let mut context =
             crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
         let secp_context = secp256k1::Secp256k1::new();

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -57,7 +57,7 @@ fn secp256k1_derive_pubkey_n_plus_one_privkey() {
     let mut context =
         crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
     let mut n_plus_one = crate::cryptography::asymmetric::ecc::secp256k1::n().clone();
-    n_plus_one.add_be_bytes(&[1]);
+    n_plus_one.add(&[1]);
 
     assert_eq!(
         context.multiply_point(
@@ -74,7 +74,7 @@ fn secp256k1_derive_pubkey_more_bytes_than_n_privkey() {
     let mut context =
         crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
     let mut n_plus_one = crate::cryptography::asymmetric::ecc::secp256k1::n().clone();
-    n_plus_one.add_be_bytes(&[1]);
+    n_plus_one.add(&[1]);
 
     assert_eq!(
         context.multiply_point(
@@ -118,8 +118,8 @@ fn secp256k1_derive_pubkey_random_privkey() {
             ) {
                 Some(p) => {
                     // secp256k1 library requires exactly 32 bytes.
-                    padded_private_key[..32 - private_key.digit_count()].fill(0);
-                    private_key.copy_digits_to(&mut padded_private_key[32 - private_key.digit_count()..]);
+                    padded_private_key[..32 - private_key.byte_count()].fill(0);
+                    private_key.copy_be_bytes_to(&mut padded_private_key[32 - private_key.byte_count()..]);
                     let expected_serialized_key_bytes =
                         secp256k1::SecretKey::from_slice(&padded_private_key)
                             .unwrap()
@@ -141,7 +141,7 @@ fn secp256k1_derive_pubkey_random_privkey() {
                     );
 
                     // Decompress the point and assert the decompressed Y coordinate is the same as the original point.
-                    decompression_buffer_x.copy_digits_from(&expected_serialized_key_bytes[1..]);
+                    decompression_buffer_x.copy_be_bytes_from(&expected_serialized_key_bytes[1..]);
                     context.calculate_y_from_x(
                         expected_serialized_key_bytes[0] == COMPRESSED_Y_IS_EVEN_IDENTIFIER,
                         &decompression_buffer_x,

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -74,7 +74,7 @@ fn secp256k1_derive_pubkey_more_bytes_than_n_privkey() {
     let mut context =
         crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
     let mut n_plus_one = crate::cryptography::asymmetric::ecc::secp256k1::n().clone();
-    n_plus_one.multiply_u64(u64::MAX);
+    n_plus_one.add_u8(1); //TODO
 
     assert_eq!(
         context.multiply_point(
@@ -111,7 +111,6 @@ fn secp256k1_derive_pubkey_random_privkey() {
                     .collect::<Vec<u8>>(),
             );
 
-            println!("{},{}P: {:?}", i, j, private_key.clone_be_bytes());
             match context.multiply_point(
                 crate::cryptography::asymmetric::ecc::secp256k1::g_x(),
                 crate::cryptography::asymmetric::ecc::secp256k1::g_y(),
@@ -129,7 +128,7 @@ fn secp256k1_derive_pubkey_random_privkey() {
 
                     println!("{},{}P: {:?}", i, j, p);
 
-                    expected_decompressed_y_buffer.set_equal_to(&p.y().borrow_unsigned());
+                    expected_decompressed_y_buffer.set_equal_to(&p.borrow_coordinates().1.borrow_unsigned());
                     let actual_serialized_key_bytes = crate::cryptography::asymmetric::ecc::secp256k1::serialized_public_key_bytes(p).unwrap();
 
                     println!("{},{}E: {:?}", i, j, expected_serialized_key_bytes);

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -22,7 +22,7 @@ use core::cmp::Ordering;
 use rand::{random, thread_rng, Rng};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
-const RANDOM_ITERATIONS: usize = 16;
+const RANDOM_ITERATIONS: usize = 100;
 
 #[test]
 fn secp256k1_derive_pubkey_zero_privkey() {

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -120,7 +120,7 @@ fn secp256k1_derive_pubkey_random_privkey() {
                 Some(p) => {
                     // secp256k1 library requires exactly 32 bytes.
                     padded_private_key[..32 - private_key.byte_count()].fill(0);
-                    private_key.copy_be_bytes_to(&mut padded_private_key[32 - private_key.byte_count()..]);
+                    assert!(private_key.try_copy_be_bytes_to(&mut padded_private_key[32 - private_key.byte_count()..]));
                     
                     let expected_key = secp256k1::SecretKey::from_slice(&padded_private_key).unwrap().public_key(&secp_context);
                     let expected_ser_bytes = expected_key.serialize();

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -32,7 +32,7 @@ fn secp256k1_derive_pubkey_zero_privkey() {
         context.multiply_point(
             crate::cryptography::asymmetric::ecc::secp256k1::g_x(),
             crate::cryptography::asymmetric::ecc::secp256k1::g_y(),
-            &BigUnsigned::with_capacity(0)
+            &BigUnsigned::with_byte_capacity(1)
         ),
         None
     );
@@ -97,11 +97,10 @@ fn secp256k1_derive_pubkey_random_privkey() {
             RANDOM_ITERATIONS / PARALLELIZED_TEST_THREAD_COUNT
         };
 
-        let mut decompression_buffer_x = BigUnsigned::with_capacity(2);
-        let mut decompression_buffer_y = BigUnsigned::with_capacity(2);
-        let mut expected_decompressed_y_buffer = BigUnsigned::with_capacity(2);
-        let mut context =
-            crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
+        let mut context = crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
+        let mut expected_decompressed_y_buffer = BigUnsigned::with_byte_capacity(32);
+        let mut decompression_buffer_x = BigUnsigned::with_byte_capacity(32);
+        let mut decompression_buffer_y = BigUnsigned::with_byte_capacity(32);
         let secp_context = secp256k1::Secp256k1::new();
         let mut padded_private_key = [0u8; 32];
 

--- a/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
+++ b/bst/src/tests/cryptography/asymmetric/scalar_multiplication.rs
@@ -57,7 +57,7 @@ fn secp256k1_derive_pubkey_n_plus_one_privkey() {
     let mut context =
         crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
     let mut n_plus_one = crate::cryptography::asymmetric::ecc::secp256k1::n().clone();
-    n_plus_one.add_u8(1);
+    n_plus_one.add_be_bytes(&[1]);
 
     assert_eq!(
         context.multiply_point(
@@ -74,7 +74,7 @@ fn secp256k1_derive_pubkey_more_bytes_than_n_privkey() {
     let mut context =
         crate::cryptography::asymmetric::ecc::secp256k1::point_multiplication_context();
     let mut n_plus_one = crate::cryptography::asymmetric::ecc::secp256k1::n().clone();
-    n_plus_one.add_u8(1); //TODO
+    n_plus_one.add_be_bytes(&[1]);
 
     assert_eq!(
         context.multiply_point(

--- a/bst/src/tests/numeric_collector.rs
+++ b/bst/src/tests/numeric_collector.rs
@@ -55,7 +55,7 @@ fn numeric_collector_multiplies_by_base_and_adds_round() {
         let mut byte_array = [0u8; 8];
         let bits = numeric_collector.bit_counter();
         let number = numeric_collector.extract_big_unsigned();
-        number.copy_be_bytes_to(&mut byte_array[8 - number.byte_count()..]);
+        assert!(number.try_copy_be_bytes_to(&mut byte_array[8 - number.byte_count()..]));
 
         let mut expected_bits = 0f64;
         let mut expected_value = 0u64;

--- a/bst/src/tests/numeric_collector.rs
+++ b/bst/src/tests/numeric_collector.rs
@@ -53,8 +53,9 @@ fn numeric_collector_multiplies_by_base_and_adds_round() {
         }
 
         let mut byte_array = [0u8; 8];
-        let collected_numeric = numeric_collector.extract_trimmed_bytes();
-        byte_array[8 - collected_numeric.data().len()..].copy_from_slice(collected_numeric.data());
+        let bits = numeric_collector.bit_counter();
+        let number = numeric_collector.extract_big_unsigned();
+        byte_array[8 - number.digit_count()..].copy_from_slice(number.borrow_digits());
 
         let mut expected_bits = 0f64;
         let mut expected_value = 0u64;
@@ -71,14 +72,6 @@ fn numeric_collector_multiplies_by_base_and_adds_round() {
         }
 
         assert_eq!(u64::from_be_bytes(byte_array), expected_value);
-        assert_eq!(collected_numeric.bit_count(), expected_bits);
-        assert_eq!(
-            collected_numeric.trimmed_byte_count(),
-            ((expected_value as f64).log(256f64).ceil() as usize).max(1)
-        );
-        assert_eq!(
-            collected_numeric.padded_byte_count(),
-            (expected_bits / 8f64).ceil() as usize
-        );
+        assert_eq!(bits, expected_bits);
     }
 }

--- a/bst/src/tests/numeric_collector.rs
+++ b/bst/src/tests/numeric_collector.rs
@@ -55,7 +55,7 @@ fn numeric_collector_multiplies_by_base_and_adds_round() {
         let mut byte_array = [0u8; 8];
         let bits = numeric_collector.bit_counter();
         let number = numeric_collector.extract_big_unsigned();
-        byte_array[8 - number.digit_count()..].copy_from_slice(number.borrow_digits());
+        number.copy_be_bytes_to(&mut byte_array[8 - number.byte_count()..]);
 
         let mut expected_bits = 0f64;
         let mut expected_value = 0u64;

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -47,7 +47,12 @@ pub fn prompt_for_bytes_from_any_data_type<TSystemServices: SystemServices>(
         cancel_prompt_string,
         label,
     ) {
-        DataInput::Number(number) => Ok(number.extract_be_bytes()),
+        DataInput::Number(mut number) => {
+            let mut bytes = vec![0u8; number.byte_count()];
+            number.copy_be_bytes_to(&mut bytes);
+            number.zero();
+            Ok(bytes)
+        }
         DataInput::None => Err(ProgramExitResult::UserCancelled),
         DataInput::Text(mut text) => {
             // Build a UTF8 buffer.

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -134,7 +134,7 @@ pub fn prompt_for_data_input<TSystemServices: SystemServices>(
 
                         // Pre-emptively zero the numeric collector; there might be sensitive data,
                         // and it's preferable to not rely on dealloc zeroing.
-                        n.extract_big_unsigned().take_data_ownership().zero();
+                        n.extract_big_unsigned().zero();
                         break DataInput::Bytes(vec);
                     }
                     None => {
@@ -154,7 +154,7 @@ pub fn prompt_for_data_input<TSystemServices: SystemServices>(
                 {
                     Some(n) => {
                         // Extract the underlying big unsigned integer and just return it.
-                        break DataInput::Number(n.extract_big_unsigned().take_data_ownership());
+                        break DataInput::Number(n.extract_big_unsigned());
                     }
                     None => {
                         if ConsoleUiConfirmationPrompt::from(system_services)
@@ -230,52 +230,6 @@ pub fn prompt_for_u32<
         u32::from_be_bytes,
         label,
         s16!("4,294,967,296 (2^32)"),
-        cancel_prompt_string,
-        system_services,
-        base,
-    )
-}
-
-#[allow(dead_code)]
-pub fn prompt_for_u64<
-    'a,
-    TSystemServices: SystemServices,
-    FValidate: Fn(u64) -> Option<String16<'a>>,
->(
-    validate: FValidate,
-    label: String16<'static>,
-    system_services: &TSystemServices,
-    cancel_prompt_string: String16<'static>,
-    base: Option<NumericBaseWithCharacterPredicate>,
-) -> Option<u64> {
-    prompt_for_unsigned_integer(
-        validate,
-        u64::from_be_bytes,
-        label,
-        s16!("18,446,744,073,709,551,616 (2^64)"),
-        cancel_prompt_string,
-        system_services,
-        base,
-    )
-}
-
-#[allow(dead_code)]
-pub fn prompt_for_u128<
-    'a,
-    TSystemServices: SystemServices,
-    FValidate: Fn(u128) -> Option<String16<'a>>,
->(
-    validate: FValidate,
-    label: String16<'static>,
-    system_services: &TSystemServices,
-    cancel_prompt_string: String16<'static>,
-    base: Option<NumericBaseWithCharacterPredicate>,
-) -> Option<u128> {
-    prompt_for_unsigned_integer(
-        validate,
-        u128::from_be_bytes,
-        label,
-        s16!("340,282,366,920,938,463,463,374,607,431,768,211,456 (2^128)"),
         cancel_prompt_string,
         system_services,
         base,

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -268,10 +268,11 @@ fn prompt_for_unsigned_integer<
             _ => return None,
         };
 
-        if number.digit_count() <= SIZE {
+        let byte_count = number.byte_count();
+        if byte_count <= SIZE {
             // If the returned number fits within the size of the requested integer, extract its bytes.
             let mut buffer = [0u8; SIZE];
-            number.copy_digits_to(&mut buffer[SIZE - number.digit_count()..]);
+            number.copy_be_bytes_to(&mut buffer[SIZE - byte_count..]);
 
             // Turn those bytes into the uint type.
             let integer = from_be_bytes(buffer);

--- a/bst/src/ui/console/data_input.rs
+++ b/bst/src/ui/console/data_input.rs
@@ -49,7 +49,7 @@ pub fn prompt_for_bytes_from_any_data_type<TSystemServices: SystemServices>(
     ) {
         DataInput::Number(mut number) => {
             let mut bytes = vec![0u8; number.byte_count()];
-            number.copy_be_bytes_to(&mut bytes);
+            assert!(number.try_copy_be_bytes_to(&mut bytes));
             number.zero();
             Ok(bytes)
         }
@@ -277,7 +277,7 @@ fn prompt_for_unsigned_integer<
         if byte_count <= SIZE {
             // If the returned number fits within the size of the requested integer, extract its bytes.
             let mut buffer = [0u8; SIZE];
-            number.copy_be_bytes_to(&mut buffer[SIZE - byte_count..]);
+            assert!(number.try_copy_be_bytes_to(&mut buffer[SIZE - byte_count..]));
 
             // Turn those bytes into the uint type.
             let integer = from_be_bytes(buffer);

--- a/bst/src/ui/console/mod.rs
+++ b/bst/src/ui/console/mod.rs
@@ -32,8 +32,8 @@ pub use clipboard::{prompt_for_clipboard_select, prompt_for_clipboard_write};
 pub use confirmation_prompt::ConsoleUiConfirmationPrompt;
 pub use continue_prompt::ConsoleUiContinuePrompt;
 pub use data_input::{
-    prompt_for_bytes_from_any_data_type, prompt_for_data_input, prompt_for_u128, prompt_for_u16,
-    prompt_for_u32, prompt_for_u64, prompt_for_u8, text_input_paste_handler,
+    prompt_for_bytes_from_any_data_type, prompt_for_data_input, prompt_for_u16, prompt_for_u32,
+    prompt_for_u8, text_input_paste_handler,
 };
 pub use key_value::ConsoleUiKeyValue;
 pub use label::ConsoleUiLabel;

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Other hashing algorithms and 'attachment' schemes could be considered.
 
 ### Asymmetric Encryption
 
-- Private & Public Key Derivation on secp256k1 - **DONE (Slow)**
+- Private & Public Key Derivation on secp256k1 - **DONE**
 - ECDSA on secp256k1 - **NOT STARTED**
 - ECIES on secp256k1 - **NOT STARTED**
 


### PR DESCRIPTION
# Long-Based Big Integer Types and Faster Division

- Rework BigUnsigned to use an easily changed digit type (options are u8, u16, u32, usize and u64, with a carry of u16, u32, u64, u64/u128, and u128 respectively).
- Use u64 and u128 for BigUnsigned arithmetic by default.
- Use binary long division rather than long division based on the digit for better division performance.
- Remove a lot of unused code (including code previously only used by tests, with reworks where necessary), particularly around big integers.
- Fix public CKD (clipboard label code used `todo!("[LABEL]")` rather than `s16!("[LABEL]")`, missed correction during initial work).

This has resulted in a dramatic performance improvement, which is felt heavily in ECC and BIP 32.

## Pre-Merge Tasks
- [x] Implementation
- [x] Self-Review
- [x] Update readme
- [x] VM testing
- [x] Bare metal testing

## Post-Merge Tasks
- [ ] New Tag
