### PR TITLE
[FEATURE] Resolution Selection

### DIFF
--- a/bst/src/console_out.rs
+++ b/bst/src/console_out.rs
@@ -18,12 +18,12 @@ use crate::{ui::Point, String16};
 use alloc::boxed::Box;
 
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-pub struct ConsoleModeInformation<TIdentifier: Clone> {
+pub struct ConsoleModeInformation<TIdentifier: ConsoleModeIdentifier> {
     identifier: TIdentifier,
     size: Point,
 }
 
-impl<TIdentifier: Clone> ConsoleModeInformation<TIdentifier> {
+impl<TIdentifier: ConsoleModeIdentifier> ConsoleModeInformation<TIdentifier> {
     pub const fn from(identifier: TIdentifier, size: Point) -> Self {
         Self { identifier, size }
     }
@@ -114,8 +114,10 @@ impl ConsoleColours {
     }
 }
 
+pub trait ConsoleModeIdentifier: Copy + Clone + Eq {}
+
 pub trait ConsoleOut: Clone {
-    type TModeIdentifer: Clone;
+    type TModeIdentifer: ConsoleModeIdentifier;
 
     fn in_colours<F: Fn(&Self) -> &Self>(&self, colours: ConsoleColours, closure: F) -> &Self {
         let original_colours = self.colours();

--- a/bst/src/console_out.rs
+++ b/bst/src/console_out.rs
@@ -114,7 +114,11 @@ impl ConsoleColours {
     }
 }
 
-pub trait ConsoleModeIdentifier: Copy + Clone + Eq {}
+pub trait ConsoleModeIdentifier: Copy + Clone + Eq {
+    fn from_be_bytes(bytes: &[u8]) -> Self;
+
+    fn to_be_bytes(&self) -> Box<[u8]>;
+}
 
 pub trait ConsoleOut: Clone {
     type TModeIdentifer: ConsoleModeIdentifier;

--- a/bst/src/console_out.rs
+++ b/bst/src/console_out.rs
@@ -121,7 +121,7 @@ pub trait ConsoleModeIdentifier: Copy + Clone + Eq {
 }
 
 pub trait ConsoleOut: Clone {
-    type TModeIdentifer: ConsoleModeIdentifier;
+    type TModeIdentifier: ConsoleModeIdentifier;
 
     fn in_colours<F: Fn(&Self) -> &Self>(&self, colours: ConsoleColours, closure: F) -> &Self {
         let original_colours = self.colours();
@@ -160,13 +160,17 @@ pub trait ConsoleOut: Clone {
 
     fn set_colours(&self, colours: ConsoleColours) -> Result<(), ConsoleColours>;
 
-    fn get_modes(&self) -> Box<[ConsoleModeInformation<Self::TModeIdentifer>]>;
+    fn get_modes(&self) -> Box<[ConsoleModeInformation<Self::TModeIdentifier>]>;
 
-    fn set_mode(&mut self, mode_identifier: Self::TModeIdentifer) -> bool;
+    fn set_mode(&mut self, mode_identifier: Self::TModeIdentifier) -> bool;
+
+    fn set_mode_from_bytes(&mut self, mode_identifier: &[u8]) -> bool {
+        self.set_mode(Self::TModeIdentifier::from_be_bytes(mode_identifier))
+    }
 
     fn blank_up_to_line_end(&self, max_within_line: usize) -> &Self;
 
-    fn current_mode_identifier(&self) -> Self::TModeIdentifer;
+    fn current_mode_identifier(&self) -> Self::TModeIdentifier;
 
     fn output_utf16<'a>(&self, string: String16<'a>) -> &Self;
 

--- a/bst/src/main.rs
+++ b/bst/src/main.rs
@@ -64,8 +64,8 @@ fn initialize_console<T: SystemServices>(
         .set_colours(colours);
 
     match system_services.try_get_variable(T::console_resolution_variable_name()) {
-        Some((b, s)) => {
-            console.set_mode_from_bytes(&b[..s]);
+        Some(b) => {
+            console.set_mode_from_bytes(&b);
         }
         None => {
             let modes = console.get_modes();

--- a/bst/src/main.rs
+++ b/bst/src/main.rs
@@ -64,8 +64,8 @@ fn initialize_console<T: SystemServices>(
         .set_colours(colours);
 
     match system_services.try_get_variable(T::console_resolution_variable_name()) {
-        Some(r) => {
-            console.set_mode_from_bytes(&r);
+        Some((b, s)) => {
+            console.set_mode_from_bytes(&b[..s]);
         }
         None => {
             let modes = console.get_modes();

--- a/bst/src/main.rs
+++ b/bst/src/main.rs
@@ -63,13 +63,20 @@ fn initialize_console<T: SystemServices>(
         .set_cursor_position(Point::ZERO)
         .set_colours(colours);
 
-    let modes = console.get_modes();
-    let mut area = 0usize;
+    match system_services.try_get_variable(T::console_resolution_variable_name()) {
+        Some(r) => {
+            console.set_mode_from_bytes(&r);
+        }
+        None => {
+            let modes = console.get_modes();
+            let mut area = 0usize;
 
-    for mode in modes.iter() {
-        let a = mode.size().area();
-        if a > area && console.set_mode(mode.identifier().clone()) {
-            area = a;
+            for mode in modes.iter() {
+                let a = mode.size().area();
+                if a > area && console.set_mode(mode.identifier().clone()) {
+                    area = a;
+                }
+            }
         }
     }
 

--- a/bst/src/programs/console/utilities/mod.rs
+++ b/bst/src/programs/console/utilities/mod.rs
@@ -16,6 +16,7 @@
 
 mod checksums;
 mod clipboard_manager;
+mod resolution_selection;
 mod value_comparer;
 
 use crate::{
@@ -39,7 +40,7 @@ pub fn get_utility_programs_list<
     program_selector: &TProgramSelector,
     exit_result_handler: &TProgramExitResultHandler,
 ) -> ProgramListProgram<TProgramSelector, TProgramExitResultHandler> {
-    let programs: [Arc<dyn Program>; 3] = [
+    let programs: [Arc<dyn Program>; 4] = [
         Arc::from(clipboard_manager::ConsoleClipboardManagerProgram::from(
             system_services.clone(),
         )),
@@ -50,6 +51,9 @@ pub fn get_utility_programs_list<
             system_services,
             program_selector,
             exit_result_handler,
+        )),
+        Arc::from(resolution_selection::ResolutionSelectionProgram::from(
+            system_services.clone(),
         )),
     ];
     ProgramList::from(Arc::from(programs), s16!("Utility Programs"))

--- a/bst/src/programs/console/utilities/resolution_selection.rs
+++ b/bst/src/programs/console/utilities/resolution_selection.rs
@@ -107,7 +107,7 @@ impl<TSystemServices: SystemServices> Program for ResolutionSelectionProgram<TSy
                     {
                         if !self.system_services.try_set_variable(
                             TSystemServices::console_resolution_variable_name(),
-                            r.identifier().to_be_bytes(),
+                            &r.identifier().to_be_bytes(),
                         ) {
                             console.in_colours(constants::ERROR_COLOURS, |c| {
                                 c.line_start()

--- a/bst/src/programs/console/utilities/resolution_selection.rs
+++ b/bst/src/programs/console/utilities/resolution_selection.rs
@@ -105,6 +105,10 @@ impl<TSystemServices: SystemServices> Program for ResolutionSelectionProgram<TSy
                     if ConsoleUiConfirmationPrompt::from(&self.system_services)
                         .prompt_for_confirmation(s16!("Save selection to NVRAM for future boots?"))
                     {
+                        self.system_services.try_clear_variable(
+                            TSystemServices::console_resolution_variable_name(),
+                        );
+
                         if !self.system_services.try_set_variable(
                             TSystemServices::console_resolution_variable_name(),
                             &r.identifier().to_be_bytes(),

--- a/bst/src/programs/console/utilities/resolution_selection.rs
+++ b/bst/src/programs/console/utilities/resolution_selection.rs
@@ -86,6 +86,7 @@ impl<TSystemServices: SystemServices> Program for ResolutionSelectionProgram<TSy
             };
 
             output();
+            console.new_line().new_line();
             let selected_resolution = list.prompt_for_selection(&self.system_services);
             match selected_resolution {
                 Some((r, _, _)) => {
@@ -93,7 +94,6 @@ impl<TSystemServices: SystemServices> Program for ResolutionSelectionProgram<TSy
                         .get_console_out()
                         .set_mode(*r.identifier());
                     output();
-
                     if !ConsoleUiConfirmationPrompt::from(&self.system_services)
                         .prompt_for_confirmation(s16!("Keep this resolution?"))
                     {

--- a/bst/src/programs/console/utilities/resolution_selection.rs
+++ b/bst/src/programs/console/utilities/resolution_selection.rs
@@ -1,0 +1,132 @@
+// Poodle Labs' Bootable Security Tools (BST)
+// Copyright (C) 2023 Isaac Beizsley (isaac@poodlelabs.com)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    console_out::{ConsoleModeIdentifier, ConsoleModeInformation, ConsoleOut},
+    constants,
+    integers::{BigUnsigned, NumericBase},
+    programs::{Program, ProgramExitResult},
+    system_services::SystemServices,
+    ui::{
+        console::{
+            ConsoleUiConfirmationPrompt, ConsoleUiLabel, ConsoleUiList, ConsoleUiTitle,
+            ConsoleWriteable,
+        },
+        ConfirmationPrompt,
+    },
+    String16,
+};
+use core::mem::size_of;
+use macros::s16;
+
+pub struct ResolutionSelectionProgram<TSystemServices: SystemServices> {
+    system_services: TSystemServices,
+}
+
+impl<TSystemServices: SystemServices> ResolutionSelectionProgram<TSystemServices> {
+    pub const fn from(system_services: TSystemServices) -> Self {
+        Self { system_services }
+    }
+}
+
+impl<TSystemServices: SystemServices> Program for ResolutionSelectionProgram<TSystemServices> {
+    fn name(&self) -> String16<'static> {
+        s16!("Resolution Selection")
+    }
+
+    fn run(&self) -> ProgramExitResult {
+        let mut console = self.system_services.get_console_out();
+        let title = ConsoleUiTitle::from(self.name(), constants::BIG_TITLE);
+        let available_resolutions = console.get_modes();
+
+        let mut list = ConsoleUiList::from(
+            ConsoleUiTitle::from(s16!("Available Resolutions"), constants::SMALL_TITLE),
+            constants::SELECT_LIST,
+            &available_resolutions[..],
+        );
+
+        loop {
+            let mode_identifier = console.current_mode_identifier();
+            let current_resolution = available_resolutions
+                .iter()
+                .find(|r| r.identifier().eq(&mode_identifier));
+
+            console.clear();
+            let output = || {
+                title.write_to(&console);
+                console
+                    .output_utf16_line(s16!(
+                        "This program lists and allows the selection of available console resolutions, with the option to save the selection into NVRAM."
+                    ));
+
+                ConsoleUiLabel::from(s16!("Current Resolution:")).write_to(&console);
+                match current_resolution {
+                    Some(r) => {
+                        r.write_to(&console);
+                    }
+                    None => {
+                        console.in_colours(constants::ERROR_COLOURS, |c| {
+                            c.output_utf16_line(s16!("Unknown"))
+                        });
+                    }
+                }
+            };
+
+            output();
+            let selected_resolution = list.prompt_for_selection(&self.system_services);
+            match selected_resolution {
+                Some((r, _, _)) => {
+                    self.system_services
+                        .get_console_out()
+                        .set_mode(*r.identifier());
+                    output();
+
+                    if !ConsoleUiConfirmationPrompt::from(&self.system_services)
+                        .prompt_for_confirmation(s16!("Keep this resolution?"))
+                    {
+                        console.set_mode(mode_identifier);
+                    }
+
+                    // TODO: NVRAM
+                }
+                None => {
+                    if ConsoleUiConfirmationPrompt::from(&self.system_services)
+                        .prompt_for_confirmation(s16!("Cancel resolution selection?"))
+                    {
+                        return ProgramExitResult::UserCancelled;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<TIdentifier: ConsoleModeIdentifier> ConsoleWriteable for ConsoleModeInformation<TIdentifier> {
+    fn write_to<T: ConsoleOut>(&self, console: &T) {
+        let mut bound_buffer = BigUnsigned::with_byte_capacity(size_of::<usize>());
+        bound_buffer.copy_be_bytes_from(&self.size().x().to_be_bytes());
+        console.output_utf16(String16::from(
+            &NumericBase::BASE_10.build_string_from_big_unsigned(&mut bound_buffer, true, 0),
+        ));
+
+        console.output_utf16(s16!("x"));
+
+        bound_buffer.copy_be_bytes_from(&self.size().y().to_be_bytes());
+        console.output_utf16(String16::from(
+            &NumericBase::BASE_10.build_string_from_big_unsigned(&mut bound_buffer, true, 0),
+        ));
+    }
+}

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -46,9 +46,10 @@ pub trait SystemServices: Clone + 'static {
 
     unsafe fn free(&self, pointer: *mut u8);
 
-    fn try_set_variable(&self, identifier: Self::TVariableIdentifier, data: Box<[u8]>) -> bool;
+    fn try_get_variable(&self, identifier: Self::TVariableIdentifier)
+        -> Option<(Box<[u8]>, usize)>;
 
-    fn try_get_variable(&self, identifier: Self::TVariableIdentifier) -> Option<Box<[u8]>>;
+    fn try_set_variable(&self, identifier: Self::TVariableIdentifier, data: Box<[u8]>) -> bool;
 
     fn console_resolution_variable_name() -> Self::TVariableIdentifier;
 

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -46,10 +46,9 @@ pub trait SystemServices: Clone + 'static {
 
     unsafe fn free(&self, pointer: *mut u8);
 
-    fn try_get_variable(&self, identifier: Self::TVariableIdentifier)
-        -> Option<(Box<[u8]>, usize)>;
+    fn try_get_variable(&self, identifier: Self::TVariableIdentifier) -> Option<Box<[u8]>>;
 
-    fn try_set_variable(&self, identifier: Self::TVariableIdentifier, data: Box<[u8]>) -> bool;
+    fn try_set_variable(&self, identifier: Self::TVariableIdentifier, data: &[u8]) -> bool;
 
     fn console_resolution_variable_name() -> Self::TVariableIdentifier;
 

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -50,6 +50,8 @@ pub trait SystemServices: Clone + 'static {
 
     fn try_set_variable(&self, identifier: Self::TVariableIdentifier, data: &[u8]) -> bool;
 
+    fn try_clear_variable(&self, identifier: Self::TVariableIdentifier) -> bool;
+
     fn console_resolution_variable_name() -> Self::TVariableIdentifier;
 
     fn execute_power_action(&self, power_action: PowerAction);

--- a/bst/src/system_services.rs
+++ b/bst/src/system_services.rs
@@ -38,12 +38,19 @@ pub enum PowerAction {
 static mut CLIPBOARD: Option<Clipboard> = None;
 
 pub trait SystemServices: Clone + 'static {
+    type TVariableIdentifier: Copy;
     type TConsoleOut: ConsoleOut + Clone;
     type TKeyboardIn: KeyboardIn + Clone;
 
     unsafe fn allocate(&self, byte_count: usize) -> *mut u8;
 
     unsafe fn free(&self, pointer: *mut u8);
+
+    fn try_set_variable(&self, identifier: Self::TVariableIdentifier, data: Box<[u8]>) -> bool;
+
+    fn try_get_variable(&self, identifier: Self::TVariableIdentifier) -> Option<Box<[u8]>>;
+
+    fn console_resolution_variable_name() -> Self::TVariableIdentifier;
 
     fn execute_power_action(&self, power_action: PowerAction);
 

--- a/bst/src/uefi/console_out.rs
+++ b/bst/src/uefi/console_out.rs
@@ -24,6 +24,7 @@ use crate::{
     String16,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
+use core::mem::size_of;
 use macros::{c16, s16};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -65,7 +66,22 @@ impl UefiConsoleOut {
 
 const NEW_LINE: String16<'static> = s16!("\r\n");
 
-impl ConsoleModeIdentifier for usize {}
+impl ConsoleModeIdentifier for usize {
+    fn from_be_bytes(bytes: &[u8]) -> Self {
+        let mut buffer = [0u8; size_of::<usize>()];
+        if bytes.len() < size_of::<usize>() {
+            buffer[size_of::<usize>() - bytes.len()..].copy_from_slice(bytes);
+        } else {
+            buffer.copy_from_slice(&bytes[bytes.len() - size_of::<usize>()..])
+        }
+
+        usize::from_be_bytes(buffer)
+    }
+
+    fn to_be_bytes(&self) -> Box<[u8]> {
+        usize::to_be_bytes(*self).into()
+    }
+}
 
 impl ConsoleOut for UefiConsoleOut {
     type TModeIdentifer = usize;

--- a/bst/src/uefi/console_out.rs
+++ b/bst/src/uefi/console_out.rs
@@ -16,7 +16,10 @@
 
 use super::protocols::{text::UefiSimpleTextOutput, UefiProtocolHandle};
 use crate::{
-    console_out::{ConsoleColours, ConsoleCursorState, ConsoleModeInformation, ConsoleOut},
+    console_out::{
+        ConsoleColours, ConsoleCursorState, ConsoleModeIdentifier, ConsoleModeInformation,
+        ConsoleOut,
+    },
     ui::Point,
     String16,
 };
@@ -61,6 +64,8 @@ impl UefiConsoleOut {
 }
 
 const NEW_LINE: String16<'static> = s16!("\r\n");
+
+impl ConsoleModeIdentifier for usize {}
 
 impl ConsoleOut for UefiConsoleOut {
     type TModeIdentifer = usize;

--- a/bst/src/uefi/console_out.rs
+++ b/bst/src/uefi/console_out.rs
@@ -84,7 +84,7 @@ impl ConsoleModeIdentifier for usize {
 }
 
 impl ConsoleOut for UefiConsoleOut {
-    type TModeIdentifer = usize;
+    type TModeIdentifier = usize;
 
     fn set_colours(&self, colours: ConsoleColours) -> Result<(), ConsoleColours> {
         if self.colours() == colours {
@@ -94,11 +94,11 @@ impl ConsoleOut for UefiConsoleOut {
         self.protocol_handle.protocol().set_colours(colours)
     }
 
-    fn get_modes(&self) -> Box<[ConsoleModeInformation<Self::TModeIdentifer>]> {
+    fn get_modes(&self) -> Box<[ConsoleModeInformation<Self::TModeIdentifier>]> {
         self.protocol_handle.protocol().get_modes()
     }
 
-    fn set_mode(&mut self, mode_identifier: Self::TModeIdentifer) -> bool {
+    fn set_mode(&mut self, mode_identifier: Self::TModeIdentifier) -> bool {
         let result = self
             .protocol_handle
             .protocol()
@@ -121,7 +121,7 @@ impl ConsoleOut for UefiConsoleOut {
         ))
     }
 
-    fn current_mode_identifier(&self) -> Self::TModeIdentifer {
+    fn current_mode_identifier(&self) -> Self::TModeIdentifier {
         self.protocol_handle.protocol().mode()
     }
 

--- a/bst/src/uefi/core_types/mod.rs
+++ b/bst/src/uefi/core_types/mod.rs
@@ -98,6 +98,7 @@ pub(in crate::uefi) enum UefiResetType {
 pub(in crate::uefi) struct UefiVariableAttributes(u32);
 
 impl UefiVariableAttributes {
+    pub const NONE: Self = Self(0x00000000);
     pub const NON_VOLATILE: Self = Self(0x00000001);
     pub const BOOTSERVICE_ACCESS: Self = Self(0x00000002);
     pub const RUNTIME_ACCESS: Self = Self(0x00000004);

--- a/bst/src/uefi/core_types/status_codes.rs
+++ b/bst/src/uefi/core_types/status_codes.rs
@@ -22,8 +22,8 @@ pub(in crate::uefi) struct UefiStatusCode(usize);
 
 impl UefiStatusCode {
     pub const SUCCESS: Self = Self(0);
-    pub const ABORTED: Self = Self(21 & Self::ERROR_BIT);
-    pub const BUFFER_TOO_SMALL: Self = Self(5 & Self::ERROR_BIT);
+    pub const ABORTED: Self = Self(21 | Self::ERROR_BIT);
+    pub const BUFFER_TOO_SMALL: Self = Self(5 | Self::ERROR_BIT);
 
     const ERROR_BIT: usize = 1usize << ((size_of::<usize>() * 8) - 1);
 

--- a/bst/src/uefi/core_types/status_codes.rs
+++ b/bst/src/uefi/core_types/status_codes.rs
@@ -23,6 +23,7 @@ pub(in crate::uefi) struct UefiStatusCode(usize);
 impl UefiStatusCode {
     pub const SUCCESS: Self = Self(0);
     pub const ABORTED: Self = Self(21 & Self::ERROR_BIT);
+    pub const BUFFER_TOO_SMALL: Self = Self(5 & Self::ERROR_BIT);
 
     const ERROR_BIT: usize = 1usize << ((size_of::<usize>() * 8) - 1);
 

--- a/bst/src/uefi/mod.rs
+++ b/bst/src/uefi/mod.rs
@@ -26,14 +26,26 @@ mod system_services;
 mod system_table;
 
 use self::{
-    core_types::{UefiEventHandle, UefiHandle, UefiStatusCode},
+    core_types::{UefiEventHandle, UefiGuid, UefiHandle, UefiStatusCode},
     system_table::UefiSystemTable,
 };
-use crate::system_services::SystemServicesAllocator;
+use crate::{system_services::SystemServicesAllocator, String16};
 use core::panic::PanicInfo;
+use macros::s16;
 use system_services::UefiSystemServices;
 
 static mut SYSTEM_SERVICES: Option<UefiSystemServices> = None;
+
+const VENDOR_GUID: UefiGuid = UefiGuid::from(
+    0xf15c91ab,
+    0x4c55,
+    0x4a93,
+    0x9a,
+    0x0c,
+    [0x44, 0xaa, 0xf1, 0xa2, 0xe5, 0xd4],
+);
+
+const CONSOLE_RESOLUTION_VARIABLE: String16<'static> = s16!("CONSOLE_RESOLUTION");
 
 fn get_system_services() -> UefiSystemServices {
     match unsafe { SYSTEM_SERVICES } {

--- a/bst/src/uefi/protocols/text/simple_text_output.rs
+++ b/bst/src/uefi/protocols/text/simple_text_output.rs
@@ -245,7 +245,7 @@ impl UefiSimpleTextOutput {
 
     pub fn get_modes(&self) -> Box<[ConsoleModeInformation<usize>]> {
         let mut vec = Vec::with_capacity(self.details.max_mode as usize);
-        for i in 0..self.details.max_mode as usize {
+        for i in 0..(self.details.max_mode as usize) + 1 {
             match self.query_mode(i) {
                 Some(p) => {
                     if p.area() > 0 {

--- a/bst/src/uefi/runtime_services.rs
+++ b/bst/src/uefi/runtime_services.rs
@@ -108,20 +108,16 @@ impl UefiRuntimeServices {
         &self,
         variable_name: String16<'static>,
         vendor_guid: &UefiGuid,
-        buffer: Option<&mut Box<[u8]>>,
+        buffer: &mut [u8],
     ) -> Result<(UefiVariableAttributes, usize), (UefiStatusCode, usize)> {
         let mut attributes = UefiVariableAttributes::NONE;
-        let (mut buffer_length, buffer) = match buffer {
-            Some(b) => (b.len(), b.as_mut_ptr()),
-            None => (0, ptr::null_mut()),
-        };
-
+        let mut buffer_length = buffer.len();
         let result = (self.get_variable)(
             unsafe { variable_name.get_underlying_slice().as_ptr() },
             vendor_guid,
             &mut attributes,
             &mut buffer_length,
-            buffer,
+            buffer.as_mut_ptr(),
         );
 
         if result.is_success() {
@@ -136,19 +132,14 @@ impl UefiRuntimeServices {
         variable_name: String16<'static>,
         vendor_guid: &UefiGuid,
         attributes: UefiVariableAttributes,
-        data: Option<Box<[u8]>>,
+        data: &[u8],
     ) -> UefiStatusCode {
-        let (buffer_length, buffer) = match data {
-            Some(b) => (b.len(), b.as_ptr()),
-            None => (0, ptr::null()),
-        };
-
         (self.set_variable)(
             unsafe { variable_name.get_underlying_slice().as_ptr() },
             vendor_guid,
             attributes,
-            buffer_length,
-            buffer,
+            data.len(),
+            data.as_ptr(),
         )
     }
 }

--- a/bst/src/uefi/runtime_services.rs
+++ b/bst/src/uefi/runtime_services.rs
@@ -142,4 +142,19 @@ impl UefiRuntimeServices {
             data.as_ptr(),
         )
     }
+
+    pub fn set_variable_empty(
+        &self,
+        variable_name: String16<'static>,
+        vendor_guid: &UefiGuid,
+        attributes: UefiVariableAttributes,
+    ) -> UefiStatusCode {
+        (self.set_variable)(
+            unsafe { variable_name.get_underlying_slice().as_ptr() },
+            vendor_guid,
+            attributes,
+            0,
+            ptr::null(),
+        )
+    }
 }

--- a/bst/src/uefi/system_services.rs
+++ b/bst/src/uefi/system_services.rs
@@ -128,6 +128,13 @@ impl SystemServices for UefiSystemServices {
         }
     }
 
+    fn try_clear_variable(&self, (variable_name, vendor_guid): Self::TVariableIdentifier) -> bool {
+        self.system_table
+            .runtime_services()
+            .set_variable_empty(variable_name, vendor_guid, UefiVariableAttributes::NONE)
+            .is_success()
+    }
+
     fn console_resolution_variable_name() -> Self::TVariableIdentifier {
         (CONSOLE_RESOLUTION_VARIABLE, &VENDOR_GUID)
     }


### PR DESCRIPTION
# Resolution Selection (#22)

- Adds a `Resolution Selection` utility program which allows users to select from a list of available console resolutions, offering the ability to save their selection to NVRAM.
- Checks whether an NVRAM setting for `CONSOLE_RESOLUTION` is set on boot, and applies it if there is one.

## Pre-Merge Tasks
- [x] Implementation
- [x] Self-Review

## Post-Merge Tasks
- [ ] New Tag
- [ ] Update #2