### PR TITLE
[ENHANCEMENT] No Hardening for BIP 32 CKD from Public Key

### DIFF
--- a/bst/src/programs/console/cryptography/bip_32/child_key_derivation.rs
+++ b/bst/src/programs/console/cryptography/bip_32/child_key_derivation.rs
@@ -196,8 +196,9 @@ impl<TSystemServices: SystemServices> Program
                 };
 
                 // Check whether this point should be hardened.
-                let is_hardened = ConsoleUiConfirmationPrompt::from(&self.system_services)
-                    .prompt_for_confirmation(s16!("Harden this derivation path point?"));
+                let is_hardened = key_type != Bip32KeyType::Public
+                    && ConsoleUiConfirmationPrompt::from(&self.system_services)
+                        .prompt_for_confirmation(s16!("Harden this derivation path point?"));
 
                 // Add the point to the derivation path.
                 derivation_path_points.push(Bip32DerivationPathPoint::from(if is_hardened {


### PR DESCRIPTION
# No Hardening for BIP 32 CKD from Public Key

The BIP 32 CKD program has been updated to not ask whether to harden each derivation path point when the parent key the child is being derived from is a public key; this would always fail, as deriving a hardened child from an extended public key is impossible, and was bad UX to even ask.

# Pre-Merge Tasks

- [x] Review

# Post-Merge Tasks

- [ ] Create Tag